### PR TITLE
Add coverage for params sent to authorize endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,5 @@ RSpec/ExampleLength:
   Max: 10
   Exclude:
     - 'spec/views/**/*'
+RSpec/MultipleMemoizedHelpers:
+  Max: 15

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.shared_context 'with an authenticated client' do |method, path, options = {}|
+RSpec.shared_context 'with an authenticated client' do |method, path|
   subject(:call_endpoint) { send(method, url, **options_for_request) }
 
   let(:url) { send(path) }
-  let(:options_for_request) { { params:, headers: } }
-  let(:params) { (options[:params] || {}).merge(client_id: 'democlient') }
-  let(:headers) { (options[:headers] || {}).merge(http_basic_auth_header) }
+  let(:options_for_request) { { params: shared_context_params, headers: shared_context_headers } }
+  let(:shared_context_params) { params.reverse_merge!(client_id: 'democlient') }
+  let(:shared_context_headers) { headers.reverse_merge!(http_basic_auth_header) }
 
   def http_basic_auth_header
     client_id = 'democlient'
@@ -20,7 +20,7 @@ end
 
 RSpec.shared_examples 'an endpoint that requires client authentication' do
   context 'without client_id param' do
-    let(:params) { nil }
+    let(:shared_context_params) { super().except(:client_id) }
 
     it 'returns HTTP status unauthorized' do
       call_endpoint
@@ -34,7 +34,7 @@ RSpec.shared_examples 'an endpoint that requires client authentication' do
   end
 
   context 'without HTTP basic auth header' do
-    let(:headers) { nil }
+    let(:shared_context_headers) { super().except('HTTP_AUTHORIZATION') }
 
     it 'returns HTTP status unauthorized' do
       call_endpoint

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -50,6 +50,14 @@ end
 
 RSpec.describe OAuthController do
   describe 'GET /authorize' do
+    let(:headers) { {} }
+    let(:params) { { client_id:, state:, code_challenge:, code_challenge_method:, response_type: } }
+    let(:client_id) { 'democlient' }
+    let(:state) { 'foobar' }
+    let(:code_challenge) { 'code_challenge' }
+    let(:code_challenge_method) { 'S256' }
+    let(:response_type) { 'code' }
+
     let(:state_token_encoder_service) { instance_double(StateTokenEncoderService, call: results) }
     let(:results) { StateTokenEncoderService::Response[status, body] }
 
@@ -65,6 +73,17 @@ RSpec.describe OAuthController do
       let(:status) { :bad_request }
       let(:body) { { errors: 'foobar' } }
 
+      it 'calls the state token encoder service with the params' do
+        call_endpoint
+        expect(StateTokenEncoderService).to have_received(:new).with(
+          client_id:,
+          client_state: state,
+          code_challenge:,
+          code_challenge_method:,
+          response_type:
+        )
+      end
+
       it 'returns http status bad request' do
         call_endpoint
         expect(response).to have_http_status(:bad_request)
@@ -79,6 +98,17 @@ RSpec.describe OAuthController do
     context 'when state token encoder service returns ok status' do
       let(:status) { :ok }
       let(:body) { 'state token' }
+
+      it 'calls the state token encoder service with the params' do
+        call_endpoint
+        expect(StateTokenEncoderService).to have_received(:new).with(
+          client_id:,
+          client_state: state,
+          code_challenge:,
+          code_challenge_method:,
+          response_type:
+        )
+      end
 
       it 'returns HTTP status ok' do
         call_endpoint


### PR DESCRIPTION
## Description
This PR refactors the shared context and shared examples to properly handle params, and it adds coverage for params sent to the authorize endpoint.

## Testing


<details>
<summary>Screenshots</summary>

Add screenshots here.
</details>
