### PR TITLE
[TAS-55] Refactor error handling for authorize endpoint to comply with spec

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -40,6 +40,11 @@ detectors:
   TooManyInstanceVariables:
     exclude:
       - StateTokenEncoderService
+  TooManyStatements:
+    exclude:
+      - OAuthController#authorize
+      - ClientRedirectUrlService#call
+      - StateTokenEncoderService#initialize
   ControlParameter:
     exclude:
       - ClientAuthentication#http_basic_auth_successful?

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ require:
 AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 RSpec/ExampleLength:
   Max: 10
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,5 @@ RSpec/ExampleLength:
     - 'spec/views/**/*'
 RSpec/MultipleMemoizedHelpers:
   Max: 15
+RSpec/NestedGroups:
+  Max: 5

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -32,7 +32,9 @@ class OAuthController < ApplicationController
       redirect_to result.url, allow_other_host: true
     end
   rescue OAuth::MissingClientIdError, OAuth::InvalidRedirectUrlError => error
-    render 'oauth/client_error', status: :bad_request, locals: { message: error.message }
+    render 'oauth/client_error',
+           status: :bad_request,
+           locals: { error_class: error.class, message: error.message }
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/app/services/client_redirect_url_service.rb
+++ b/app/services/client_redirect_url_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'oauth'
+
 ##
 # Service which returns a valid client redirect url with provided params
 class ClientRedirectUrlService < ApplicationService
@@ -14,7 +16,13 @@ class ClientRedirectUrlService < ApplicationService
   def call
     redirect_url = url_from_config
     redirect_url.query = encoded_params
+    unless redirect_url.is_a?(URI::HTTP) || redirect_url.is_a?(URI::HTTPS)
+      raise OAuth::InvalidRedirectUrlError, I18n.t('services.client_redirect_url_service.invalid_scheme')
+    end
+
     Response[redirect_url.to_s]
+  rescue URI::InvalidURIError, ArgumentError => error
+    raise OAuth::InvalidRedirectUrlError, error.message
   end
 
   private

--- a/app/services/client_redirect_url_service.rb
+++ b/app/services/client_redirect_url_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+##
+# Service which returns a valid client redirect url with provided params
+class ClientRedirectUrlService < ApplicationService
+  Response = Data.define(:url)
+
+  def initialize(client_id:, params:)
+    super()
+    @client_id = client_id
+    @params = params
+  end
+
+  def call
+    redirect_url = url_from_config
+    redirect_url.query = encoded_params
+    Response[redirect_url.to_s]
+  end
+
+  private
+
+  attr_reader :client_id, :params
+  attr_accessor :redirect_url
+
+  def url_from_config
+    URI(Rails.configuration.oauth.clients.dig(client_id.to_sym, :redirection_uri))
+  end
+
+  def encoded_params
+    URI.encode_www_form(params_for_query)
+  end
+
+  def params_for_query
+    params.collect { |key, value| [key.to_s, value] }
+  end
+end

--- a/app/services/state_token_encoder_service.rb
+++ b/app/services/state_token_encoder_service.rb
@@ -20,7 +20,7 @@ class StateTokenEncoderService < ApplicationService
   end
 
   def call
-    return Response[:bad_request, { errors: errors_from_params }] if errors_from_params.present?
+    return Response[:invalid_request, { errors: errors_from_params }] if errors_from_params.present?
 
     payload = { client_id:, client_state:, code_challenge:, code_challenge_method:, response_type: }
     Response[:ok, JsonWebToken.encode(payload)]

--- a/app/views/oauth/client_error.html.erb
+++ b/app/views/oauth/client_error.html.erb
@@ -1,0 +1,9 @@
+<div class="flex h-screen">
+  <div class="block w-full m-auto">
+    <div class="card">
+      <%= tag.h2 t('.title'), class: 'text-2xl semibold mb-2' %>
+      <%= tag.p t('.lede'), class: 'mb-2' %>
+      <%= tag.p message, class: 'text-center text-red-800 bg-red-200 rounded border-1 border-red-800 p-4' %>
+    </div>
+  </div>
+</div>

--- a/app/views/oauth/client_error.html.erb
+++ b/app/views/oauth/client_error.html.erb
@@ -3,7 +3,10 @@
     <div class="card">
       <%= tag.h2 t('.title'), class: 'text-2xl semibold mb-2' %>
       <%= tag.p t('.lede'), class: 'mb-2' %>
-      <%= tag.p message, class: 'text-center text-red-800 bg-red-200 rounded border-1 border-red-800 p-4' %>
+      <div class="text-center text-red-800 bg-red-200 rounded border-1 border-red-800 p-4">
+        <%= tag.h3 error_class, class: 'text-xl semibold' %>
+        <%= tag.p message %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/oauth/en.yml
+++ b/config/locales/oauth/en.yml
@@ -1,2 +1,5 @@
 en:
   oauth:
+    client_error:
+      title: 'Client Error'
+      lede: 'The request provided by the client to this server is malformed. Please report this error through the client support channel.'

--- a/config/locales/services/en.yml
+++ b/config/locales/services/en.yml
@@ -2,3 +2,5 @@ en:
   services:
     state_token_encoder:
       invalid_param: 'The value passed for %{param} is invalid. Value provided: %{value}'
+    client_redirect_url_service:
+      invalid_scheme: 'Invalid URL scheme provided.'

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+##
+# Provides errors for OAuth server
+module OAuth
+  ##
+  # Error for when client_id param is missing.
+  class MissingClientIdError < StandardError
+    def initialize(msg = 'Request does not contain required parameter: client_id')
+      super
+    end
+  end
+end

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -10,4 +10,8 @@ module OAuth
       super
     end
   end
+
+  ##
+  # Error for when client redirection URI is invalid.
+  class InvalidRedirectUrlError < StandardError; end
 end

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -69,6 +69,15 @@ RSpec.describe OAuthController do
 
     it_behaves_like 'an endpoint that requires client authentication'
 
+    context 'when the client_id param is missing' do
+      let(:shared_context_params) { super().except!(:client_id) }
+
+      it 'responds with HTTP status bad request' do
+        call_endpoint
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
     context 'when state token encoder service returns bad request status' do
       let(:status) { :bad_request }
       let(:body) { { errors: 'foobar' } }

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe OAuthController do
       end
     end
 
-    context 'when state token encoder service returns bad request status' do
-      let(:status) { :bad_request }
+    context 'when state token encoder service returns invalid_request status' do
+      let(:status) { :invalid_request }
       let(:body) { { errors: 'foobar' } }
 
       it 'calls the state token encoder service with the params' do

--- a/spec/services/client_redirect_url_service_spec.rb
+++ b/spec/services/client_redirect_url_service_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClientRedirectUrlService do
+  describe '.call' do
+    subject(:service_call) do
+      described_class.new(client_id:, params:).call
+    end
+
+    let(:client_id) { 'democlient' }
+    let(:params) { { foo: 'oof', bar: 'rab' } }
+
+    it 'returns the redirect_url with params for the provided client' do
+      expect(service_call.url).to eq('http://localhost:3000/?foo=oof&bar=rab')
+    end
+  end
+end

--- a/spec/services/client_redirect_url_service_spec.rb
+++ b/spec/services/client_redirect_url_service_spec.rb
@@ -8,11 +8,22 @@ RSpec.describe ClientRedirectUrlService do
       described_class.new(client_id:, params:).call
     end
 
-    let(:client_id) { 'democlient' }
     let(:params) { { foo: 'oof', bar: 'rab' } }
 
-    it 'returns the redirect_url with params for the provided client' do
-      expect(service_call.url).to eq('http://localhost:3000/?foo=oof&bar=rab')
+    context 'with valid client config' do
+      let(:client_id) { 'democlient' }
+
+      it 'returns the redirect_url with params for the provided client' do
+        expect(service_call.url).to eq('http://localhost:3000/?foo=oof&bar=rab')
+      end
+    end
+
+    context 'with invalid client config' do
+      let(:client_id) { 'invalidclient' }
+
+      it 'raises an OAuth::InvalidRedirectUrlError' do
+        expect { service_call }.to raise_error(OAuth::InvalidRedirectUrlError)
+      end
     end
   end
 end

--- a/spec/services/state_token_encoder_service_spec.rb
+++ b/spec/services/state_token_encoder_service_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.shared_examples 'returns status and errors for invalid param' do |param|
-  it 'returns bad_request status' do
-    expect(service_call.status).to eq(:bad_request)
+  it 'returns invalid_request status' do
+    expect(service_call.status).to eq(:invalid_request)
   end
 
   it 'returns invalid param error message' do

--- a/spec/views/oauth/client_error.html.tailwindcss_spec.rb
+++ b/spec/views/oauth/client_error.html.tailwindcss_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'oauth/client_error' do
+  before do
+    render template: 'oauth/client_error', locals: { message: 'foobar' }
+  end
+
+  it 'renders the title' do
+    expect(rendered).to match(/#{I18n.t('oauth.client_error.title')}/)
+  end
+
+  it 'renders the lede' do
+    expect(rendered).to match(/#{I18n.t('oauth.client_error.lede')}/)
+  end
+
+  it 'renders the message' do
+    expect(rendered).to match(/foobar/)
+  end
+end

--- a/spec/views/oauth/client_error.html.tailwindcss_spec.rb
+++ b/spec/views/oauth/client_error.html.tailwindcss_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'oauth/client_error' do
   before do
-    render template: 'oauth/client_error', locals: { message: 'foobar' }
+    render template: 'oauth/client_error', locals: { error_class: 'foo', message: 'bar' }
   end
 
   it 'renders the title' do
@@ -15,7 +15,11 @@ RSpec.describe 'oauth/client_error' do
     expect(rendered).to match(/#{I18n.t('oauth.client_error.lede')}/)
   end
 
-  it 'renders the message' do
-    expect(rendered).to match(/foobar/)
+  it 'renders the error class' do
+    expect(rendered).to match(/foo/)
+  end
+
+  it 'renders the error message' do
+    expect(rendered).to match(/bar/)
   end
 end


### PR DESCRIPTION
## Description

This PR refactors the error handling for the `authorize` endpoint to more closely comply with the spec. See [here](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1). There are a number of different error conditions which I'm skipping for now.

I chose to focus on handling client errors such as a missing client_id and invalid client redirect URI by displaying a client error template that includes the error class and message to the end-user, as called for in the spec.

Also, I refactored the authorize endpoint to return the appropriate status code for invalid parameters (`invalid_request`) through a redirect; the previous implementation rendered a JSON response with the errors which was not compliant with the spec at all.

<details>
<summary>Screenshots</summary>

### Missing client_id param
<img width="1005" alt="Screenshot 2023-08-23 at 8 37 22 PM" src="https://github.com/dickdavis/oauth-flow-demo/assets/10838930/32e0ec36-150a-49f2-9813-a4fe9c0575ae">

### Invalid client redirection_uri
<img width="940" alt="Screenshot 2023-08-23 at 8 44 34 PM" src="https://github.com/dickdavis/oauth-flow-demo/assets/10838930/e61cb8a4-669d-40b2-aee9-ba3079f300d0">

</details>

## Testing

### Happy Path

* Ensure that you have both the development and test keys; they aren't committed to source control, so you'll need to get them from me directly via Slack.
* Execute the manual testing script by using the following command: bin/rails r script/manual_testing.rb
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Verify that the sign in form renders.

### Missing client_id param

* Ensure that you have both the development and test keys; they aren't committed to source control, so you'll need to get them from me directly via Slack.
* Execute the manual testing script by using the following command: bin/rails r script/manual_testing.rb
* Copy the URL generated by the script, paste it in your browser, remove the client_id param, and send the request.
* Verify the client error page is displayed with the error class and message.

### Invalid param and invalid client redirect_uri

* Open the `config/oauth.yml` file, remove the `redirection_uri` entry for the `democlient` client, and save the file.
* Restart the rails server.
* Execute the manual testing script by using the following command: bin/rails r script/manual_testing.rb
* Copy the URL generated by the script, change the `response_type` to something other than `code`, paste it in your browser, and send the request.
* Verify the client error page is displayed with the error class and message.

### Invalid param

* Ensure the `redirection_uri` entry has been added back to the `democlient` client config.
* Restart the rails server.
* Execute the manual testing script by using the following command: bin/rails r script/manual_testing.rb
* Copy the URL generated by the script, change the `response_type` to something other than `code`, paste it in your browser, and send the request.
* Verify the page redirects to the callback with the error param (and state param if passed on the original request)
  * Example with just error param: `http://localhost:3000/?error=invalid_request`
  * Example when state param was passed by client on original request: `http://localhost:3000/?error=invalid_request&state=test`




