### PR TITLE
Revert change to sign_in page

### DIFF
--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -17,7 +17,7 @@ class OAuthController < ApplicationController
 
     case status
     when :ok
-      render 'oauth/authorize', locals: { state: body }
+      redirect_to sign_in_path(state: body)
     when :bad_request
       render json: body, status:
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,10 @@
 ##
 # Controller for logging in users.
 class SessionsController < ApplicationController
+  def new
+    render 'sessions/new', locals: { state: params[:state] }
+  end
+
   # rubocop:disable Metrics/AbcSize
   def create
     user = User.find_by(email: params[:email])
@@ -12,7 +16,7 @@ class SessionsController < ApplicationController
       redirect_to root_path
     else
       flash.now.alert = t('.login_failure')
-      render 'oauth/authorize', locals: { state: params[:state] }
+      render 'sessions/new', locals: { state: params[:state] }
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <div class="block w-full m-auto">
     <div class="card">
       <%= tag.p alert, class: 'text-center text-red-800 bg-red-200 rounded border-1 border-red-800 p-4' if alert %>
-      <%= form_with(url: sign_in_path, method: 'post', data: { turbo: "false" }) do |form| %>
+      <%= form_with(url: sign_in_path, method: 'post', data: { turbo: 'false' }) do |form| %>
         <%= form.hidden_field :state, value: state %>
         <div class="my-3">
           <%= form.label :email, class: 'form-label' %>

--- a/config/locales/oauth/en.yml
+++ b/config/locales/oauth/en.yml
@@ -1,4 +1,2 @@
 en:
   oauth:
-    authorize:
-      submit: 'Login'

--- a/config/locales/sessions/en.yml
+++ b/config/locales/sessions/en.yml
@@ -1,4 +1,6 @@
 en:
   sessions:
+    new:
+      submit: 'Login'
     create:
       login_failure: 'Invalid email/password combination.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@
 Rails.application.routes.draw do
   resources :users, only: %i[new create]
 
-  post 'sign-in', to: 'sessions#create', as: :sign_in
+  get 'sign-in', to: 'sessions#new', as: :sign_in
+  post 'sign-in', to: 'sessions#create'
   delete 'sign-out', to: 'sessions#destroy', as: :sign_out
 
   get 'authorize', to: 'oauth#authorize'

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe OAuthController do
         )
       end
 
-      it 'returns HTTP status ok' do
+      it 'redirects the user to the sign in page' do
         call_endpoint
-        expect(response).to have_http_status(:ok)
+        expect(response).to redirect_to(sign_in_path(state: body))
       end
     end
   end

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe SessionsController do
+  describe 'GET /new' do
+    subject(:call_endpoint) { get sign_in_path }
+
+    it 'renders a successful response' do
+      call_endpoint
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe 'POST /create' do
     subject(:call_endpoint) { post sign_in_path, params: }
 

--- a/spec/routing/sessions_routing_spec.rb
+++ b/spec/routing/sessions_routing_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe SessionsController do
   describe 'routing' do
+    it 'routes to #new' do
+      expect(get: '/sign-in').to route_to('sessions#new')
+    end
+
     it 'routes to #create' do
       expect(post: '/sign-in').to route_to('sessions#create')
     end

--- a/spec/views/sessions/new.html.tailwindcss_spec.rb
+++ b/spec/views/sessions/new.html.tailwindcss_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe 'oauth/authorize' do
+RSpec.describe 'sessions/new' do
   it 'renders log in form' do
-    render template: 'oauth/authorize', locals: { state: 'state token' }
+    render template: 'sessions/new', locals: { state: 'state token' }
 
     assert_select 'form[action=?][method=?]', sign_in_path, 'post' do
       assert_select 'input[type=hidden][name=?]', 'state'


### PR DESCRIPTION
## Description
This PR reverts a misguided attempt to gradually subsume the sessions controller into the oauth controller. Keeping the two separate is doable; previously, I thought that it was necessary to eliminate use of the session for user authentication altogether, but it is clear that is not the case.

## Testing


<details>
<summary>Screenshots</summary>

Add screenshots here.
</details>
