### PR TITLE
[TAS-14] Implement token endpoint with basic error responses

### DIFF
--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -6,4 +6,8 @@ class ApplicationService
   def self.call(...)
     new(...).call
   end
+
+  def self.call!(...)
+    new(...).call!
+  end
 end

--- a/app/services/token_request_validator_service.rb
+++ b/app/services/token_request_validator_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+##
+# Service which validates a token request
+class TokenRequestValidatorService < ApplicationService
+  def initialize(authorization_grant:, code_verifier:, grant_type:)
+    super()
+    @authorization_grant = authorization_grant
+    @code_verifier = code_verifier
+    @grant_type = grant_type
+  end
+
+  def call
+    call!
+    true
+  rescue OAuth::UnsupportedGrantTypeError, OAuth::InvalidGrantError, OAuth::InvalidRequestError
+    false
+  end
+
+  def call!
+    raise OAuth::UnsupportedGrantTypeError if invalid_grant_type?
+    raise OAuth::InvalidGrantError if invalid_authorization_grant?
+    raise OAuth::InvalidRequestError if invalid_code_verifier?
+
+    true
+  end
+
+  private
+
+  attr_reader :authorization_grant, :code_verifier, :grant_type
+
+  def invalid_grant_type?
+    grant_type != 'authorization_code'
+  end
+
+  def invalid_authorization_grant?
+    authorization_grant.blank? || authorization_grant.redeemed?
+  end
+
+  def invalid_code_verifier?
+    challenge = Digest::SHA256.base64digest(code_verifier).tr('+/', '-_').tr('=', '')
+    authorization_grant.code_challenge != challenge
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   delete 'sign-out', to: 'sessions#destroy', as: :sign_out
 
   get 'authorize', to: 'oauth#authorize'
+  post 'token', to: 'oauth#token'
 
   resources :authorization_grants, path: 'authorization-grants', only: %i[new create]
 

--- a/db/migrate/20230828195628_add_redeemed_to_authorization_grants.rb
+++ b/db/migrate/20230828195628_add_redeemed_to_authorization_grants.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+##
+# Adds the redeemed column to authorization_grants to track when codes have been used.
+class AddRedeemedToAuthorizationGrants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :authorization_grants, :redeemed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_24_164527) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_28_195628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_164527) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "redeemed", default: false, null: false
     t.index ["user_id"], name: "index_authorization_grants_on_user_id"
   end
 

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -18,4 +18,16 @@ module OAuth
   ##
   # Error for when resource owner denies access request.
   class AccessDenied < StandardError; end
+
+  ##
+  # Error for when client provides an unsupported grant type param.
+  class UnsupportedGrantTypeError < StandardError; end
+
+  ##
+  # Error for when client provides a code that does not map to an valid authorization grant.
+  class InvalidGrantError < StandardError; end
+
+  ##
+  # Error for when client provides a param that fails validation.
+  class InvalidRequestError < StandardError; end
 end

--- a/script/manual_testing.rb
+++ b/script/manual_testing.rb
@@ -25,25 +25,21 @@ puts <<~TEXT
   client_secret: #{client_secret}
 TEXT
 
-# puts 'Authorization code? -> '
-# authorization_code = gets.chomp
-#
-# uri = URI.parse('https://api.dropbox.com/oauth2/token')
-# request = Net::HTTP::Post.new(uri)
-# request.set_form_data(
-#   'client_id' => app_key,
-#   'code' => authorization_code,
-#   'code_verifier' => code_verifier,
-#   'grant_type' => 'authorization_code',
-# )
-#
-# req_options = {
-#   use_ssl: uri.scheme == 'https',
-# }
-#
-# response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
-#   http.request(request)
-# end
-#
-# puts response.body
+puts 'Authorization code? -> '
+authorization_code = gets.chomp
+
+uri = URI.parse('http://localhost:3000/token')
+request = Net::HTTP::Post.new(uri)
+request.basic_auth(client_id, client_secret)
+request.set_form_data(
+  'code' => authorization_code,
+  'code_verifier' => code_verifier,
+  'grant_type' => 'authorization_code'
+)
+
+response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+  http.request(request)
+end
+
+puts response.body
 # puts "Access token: #{response.body['access_token']}"

--- a/spec/factories/authorization_grants.rb
+++ b/spec/factories/authorization_grants.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     expires_at { 9.minutes.from_now }
     client_id { 'democlient' }
     client_redirection_uri { 'http://localhost:3000/' }
+    redeemed { false }
     user
   end
 end

--- a/spec/routing/oauth_routing_spec.rb
+++ b/spec/routing/oauth_routing_spec.rb
@@ -7,5 +7,9 @@ RSpec.describe OAuthController do
     it 'routes to #authorize' do
       expect(get: '/authorize').to route_to('oauth#authorize')
     end
+
+    it 'routes to #token' do
+      expect(post: '/token').to route_to('oauth#token')
+    end
   end
 end

--- a/spec/services/token_request_validator_service_spec.rb
+++ b/spec/services/token_request_validator_service_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TokenRequestValidatorService do
+  describe '.call' do
+    subject(:service_call) do
+      described_class.new(authorization_grant:, code_verifier:, grant_type:).call
+    end
+
+    let(:authorization_grant) { create(:authorization_grant) }
+    let(:code_verifier) { 'code_verifier' }
+    let(:grant_type) { 'authorization_code' }
+
+    context 'when the code is not a valid authorization code' do
+      let(:authorization_grant) { nil }
+
+      it 'returns false' do
+        expect(service_call).to be_falsey
+      end
+    end
+
+    context 'when the code is has already been redeemed' do
+      let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
+
+      it 'returns false' do
+        expect(service_call).to be_falsey
+      end
+    end
+
+    context 'when the code verifier does not match the code challenge for the authorization grant' do
+      let(:code_verifier) { 'foobar' }
+
+      it 'returns false' do
+        expect(service_call).to be_falsey
+      end
+    end
+
+    context 'when the grant_type is not authorization_code' do
+      let(:grant_type) { 'foobar' }
+
+      it 'returns false' do
+        expect(service_call).to be_falsey
+      end
+    end
+
+    context 'when provided params are valid' do
+      it 'returns true' do
+        expect(service_call).to be_truthy
+      end
+    end
+  end
+
+  describe '.call!' do
+    subject(:service_call) do
+      described_class.new(authorization_grant:, code_verifier:, grant_type:).call!
+    end
+
+    let(:authorization_grant) { create(:authorization_grant) }
+    let(:code_verifier) { 'code_verifier' }
+    let(:grant_type) { 'authorization_code' }
+
+    context 'when the code is not a valid authorization code' do
+      let(:authorization_grant) { nil }
+
+      it 'raises an OAuth::UnsupportedGrantTypeError' do
+        expect { service_call }.to raise_error(OAuth::InvalidGrantError)
+      end
+    end
+
+    context 'when the code is has already been redeemed' do
+      let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
+
+      it 'raises an OAuth::UnsupportedGrantTypeError' do
+        expect { service_call }.to raise_error(OAuth::InvalidGrantError)
+      end
+    end
+
+    context 'when the code verifier does not match the code challenge for the authorization grant' do
+      let(:code_verifier) { 'foobar' }
+
+      it 'raises an OAuth::InvalidRequestError' do
+        expect { service_call }.to raise_error(OAuth::InvalidRequestError)
+      end
+    end
+
+    context 'when the grant_type is not authorization_code' do
+      let(:grant_type) { 'foobar' }
+
+      it 'raises an OAuth::UnsupportedGrantTypeError' do
+        expect { service_call }.to raise_error(OAuth::UnsupportedGrantTypeError)
+      end
+    end
+
+    context 'when provided params are valid' do
+      it 'returns true' do
+        expect(service_call).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR adds the `/token` endpoint with basic error responses. This initial PR only implements the error responses since adding full functionality would be quite beefy 🐮 . I've implemented a token request validator service that raises either an invalid grant error, unsupported grant type error, or an invalid request error, depending on the request params. The error is handled by the controller action which then responds with the appropriate error status.

If the `grant_type` is anything other than "authorization_code", the validator raises an `UnsupportedGrantTypeError` and the controller returns the `unsupported_grant_type` error response per the spec.

If the `authorization_code` provided does not map to an existing record or if the corresponding record has already been redeemed, the validator raises an `InvalidGrantError` and the controller returns the `invalid_grant` error response per the spec.

It the `code_verifier` does not match up with the `code_challenge` saved in the original authorization grant, the validator raises an `InvalidRequestError` and the controller returns the `invalid_request` error response.

<details>
<summary>Screenshots</summary>

Add screenshots here.
</details>

## Testing

### Authorization code already redeemed

* Ensure the user is signed in.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Open the rails console.
* Find the `AuthorizationGrant` with the id corresponding to the auth code returned in the query parameters.
* Update the `AuthorizationGrant` record to have `redeemed` set to true.
* Enter the authorization code at the prompt in the manual testing script.
* Verify the response is `{"error":"invalid_grant"}`

### Authorization code doesn't exist

* Ensure the user is signed in.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Enter an invalid authorization code at the prompt in the manual testing script (anything that doesn't map to a real authorization code in the DB).
* Verify the response is `{"error":"invalid_grant"}`

### Unsupported grant type

* Ensure the user is signed in.
* Edit the line 37 of the manual testing script to pass any value of `grant_type` other than `authorization_code`.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Enter the authorization code at the prompt in the manual testing script.
* Verify the response is `{"error":"invalid_grant"}`

### Invalid code verifier

* Ensure the user is signed in.
* Edit the line 36 of the manual testing script to pass any value for `code_verifier` other than the variable `code_verifier` which is generated by the script; any string will do.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Enter the authorization code at the prompt in the manual testing script.
* Verify the response is `{"error":"invalid_request"}`

### Valid params

* Ensure the user is signed in.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Enter the authorization code at the prompt in the manual testing script.
* Verify the response body is empty.
* Check the rails server logs to verify a 204 no content was returned.