### PR TITLE
[TAS-56] Generate and return access and refresh tokens

### DIFF
--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -35,20 +35,45 @@ class OAuthController < ApplicationController
            status: :bad_request,
            locals: { error_class: error.class, message: error.message }
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   def token
     authorization_grant = AuthorizationGrant.find_by(id: params[:code])
     TokenRequestValidatorService.call!(
       authorization_grant:, code_verifier: params[:code_verifier], grant_type: params[:grant_type]
     )
+
+    client_id = authorization_grant.client_id
+    access_token_expiration = 5.minutes.from_now
+    access_token_jti, access_token = OAuthTokenEncoderService.call(
+      client_id:,
+      expiration: access_token_expiration,
+      optional_claims: { user_id: authorization_grant.user_id }
+    ).deconstruct
+
+    refresh_token_jti, refresh_token = OAuthTokenEncoderService.call(
+      client_id:,
+      expiration: 14.days.from_now
+    ).deconstruct
+
+    oauth_session = OAuthSession.new(access_token_jti:, refresh_token_jti:, authorization_grant:)
+    if oauth_session.save
+      authorization_grant.update(redeemed: true)
+      render json: { access_token:, refresh_token:, token_type: 'bearer', expires_in: access_token_expiration.to_i }
+    else
+      errors = oauth_session.errors.full_messages.join(', ')
+      raise OAuth::ServerError, I18n.t('oauth.server_error.oauth_session_failure', errors:)
+    end
   rescue OAuth::UnsupportedGrantTypeError
-    render json: { error: 'unsupported_grant_type' }, status: :bad_request
+    render_token_request_error(error: 'unsupported_grant_type')
   rescue OAuth::InvalidGrantError
-    render json: { error: 'invalid_grant' }, status: :bad_request
+    render_token_request_error(error: 'invalid_grant')
   rescue OAuth::InvalidRequestError
-    render json: { error: 'invalid_request' }, status: :bad_request
+    render_token_request_error(error: 'invalid_request')
+  rescue OAuth::ServerError => error
+    Rails.logger.error(error.message)
+    render_token_request_error(error: 'server_error', status: :internal_server_error)
   end
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   private
 
@@ -64,5 +89,9 @@ class OAuthController < ApplicationController
 
       secret == Rails.application.credentials.clients[id.to_sym]
     end
+  end
+
+  def render_token_request_error(error:, status: :bad_request)
+    render json: { error: }, status:
   end
 end

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -43,7 +43,7 @@ class OAuthController < ApplicationController
     )
 
     client_id = authorization_grant.client_id
-    access_token_expiration = 5.minutes.from_now
+    access_token_expiration = oauth_config.access_token_expiration.minutes.from_now
     access_token_jti, access_token = OAuthTokenEncoderService.call(
       client_id:,
       expiration: access_token_expiration,
@@ -52,7 +52,7 @@ class OAuthController < ApplicationController
 
     refresh_token_jti, refresh_token = OAuthTokenEncoderService.call(
       client_id:,
-      expiration: 14.days.from_now
+      expiration: oauth_config.refresh_token_expiration.minutes.from_now
     ).deconstruct
 
     oauth_session = OAuthSession.new(access_token_jti:, refresh_token_jti:, authorization_grant:)
@@ -76,6 +76,10 @@ class OAuthController < ApplicationController
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   private
+
+  def oauth_config
+    @oauth_config ||= Rails.configuration.oauth
+  end
 
   def authenticate_client
     return if http_basic_auth_successful?

--- a/app/models/authorization_grant.rb
+++ b/app/models/authorization_grant.rb
@@ -6,6 +6,7 @@ class AuthorizationGrant < ApplicationRecord
   VALID_CODE_CHALLENGE_METHODS = %w[S256].freeze
 
   belongs_to :user
+  has_many :oauth_sessions, dependent: :destroy
 
   before_validation :generate_expires_at
 

--- a/app/models/oauth_session.rb
+++ b/app/models/oauth_session.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+##
+# Models an oauth session with minimal data from session.
+class OAuthSession < ApplicationRecord
+  STATUS_ENUM_VALUES = {
+    created: 'created',
+    expired: 'expired',
+    refreshed: 'refreshed',
+    revoked: 'revoked'
+  }.freeze
+
+  VALID_UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/i
+
+  validates :access_token_jti, presence: true, uniqueness: true, format: { with: VALID_UUID_REGEX }
+  encrypts :access_token_jti, deterministic: true
+
+  validates :refresh_token_jti, presence: true, uniqueness: true, format: { with: VALID_UUID_REGEX }
+  encrypts :refresh_token_jti, deterministic: true
+
+  belongs_to :authorization_grant
+
+  enum status: STATUS_ENUM_VALUES, _suffix: true
+end

--- a/app/services/oauth_token_encoder_service.rb
+++ b/app/services/oauth_token_encoder_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+##
+# Service which encodes access and refresh tokens.
+class OAuthTokenEncoderService < ApplicationService
+  Response = Data.define(:jti, :token)
+
+  def initialize(client_id:, expiration:, optional_claims: {})
+    super()
+    @client_id = client_id
+    @expiration = expiration
+    @optional_claims = optional_claims
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def call
+    raise OAuth::ServerError, invalid_param_message(:client_id) unless valid_client_id?
+    raise OAuth::ServerError, invalid_param_message(:expiration) unless valid_expiration?
+
+    payload = {
+      aud: client_id,
+      iat: Time.zone.now.to_i,
+      iss: Rails.configuration.oauth.issuer_url,
+      jti: SecureRandom.uuid
+    }.merge(optional_claims)
+
+    token = JsonWebToken.encode(payload, expiration)
+
+    Response[payload[:jti], token]
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  private
+
+  attr_reader :client_id, :expiration, :optional_claims
+
+  def valid_client_id?
+    client_id.present? && Rails.configuration.oauth.clients.key?(client_id.to_sym)
+  end
+
+  def valid_expiration?
+    expiration.is_a?(ActiveSupport::TimeWithZone)
+  end
+
+  def invalid_param_message(param)
+    I18n.t("services.oauth_token_encoder_service.invalid_#{param}", value: send(param))
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,6 @@ module OauthFlowDemo
     config.generators.system_tests = nil
 
     config.oauth = config_for(:oauth)
+    config.active_record.encryption.extend_queries = true
   end
 end

--- a/config/locales/oauth/en.yml
+++ b/config/locales/oauth/en.yml
@@ -3,3 +3,5 @@ en:
     client_error:
       title: 'Client Error'
       lede: 'The request provided by the client to this server is malformed. Please report this error through the client support channel.'
+    server_error:
+      oauth_session_failure: 'Failed to create OAuthSession. Errors: %{errors}'

--- a/config/locales/services/en.yml
+++ b/config/locales/services/en.yml
@@ -4,3 +4,6 @@ en:
       invalid_param: 'The value passed for %{param} is invalid. Value provided: %{value}'
     client_redirect_url_service:
       invalid_scheme: 'Invalid URL scheme provided.'
+    oauth_token_encoder_service:
+      invalid_client_id: 'Invalid value for client_id provided. Value provided: %{value}'
+      invalid_expiration: 'Invalid value for expiration provided. Value provided: %{value}'

--- a/config/oauth.yml
+++ b/config/oauth.yml
@@ -1,5 +1,7 @@
 development:
   issuer_url: 'htt://localhost:3000/'
+  access_token_expiration: 5 # In minutes
+  refresh_token_expiration: 20160 # In minutes (14 days)
   clients:
     democlient:
       name: 'Demo Client'
@@ -8,6 +10,8 @@ development:
 
 test:
   issuer_url: 'htt://localhost:3000/'
+  access_token_expiration: 5 # In minutes
+  refresh_token_expiration: 20160 # In minutes (14 days)
   clients:
     democlient:
       name: 'Demo Client'

--- a/config/oauth.yml
+++ b/config/oauth.yml
@@ -1,4 +1,5 @@
 development:
+  issuer_url: 'htt://localhost:3000/'
   clients:
     democlient:
       name: 'Demo Client'
@@ -6,6 +7,7 @@ development:
       redirection_uri: 'http://localhost:3000/'
 
 test:
+  issuer_url: 'htt://localhost:3000/'
   clients:
     democlient:
       name: 'Demo Client'

--- a/db/migrate/20230829150719_create_oauth_sessions.rb
+++ b/db/migrate/20230829150719_create_oauth_sessions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+##
+# Creates oauth_sessions table.
+class CreateOAuthSessions < ActiveRecord::Migration[7.0]
+  def change
+    create_enum :oauth_session_status, %w[created expired refreshed revoked]
+    create_table :oauth_sessions, id: :uuid do |table|
+      table.string :access_token_jti, null: false
+      table.string :refresh_token_jti, null: false
+      table.enum :status, enum_type: :oauth_session_status, default: 'created', null: false
+      table.belongs_to :authorization_grant, null: false, type: :uuid, foreign_key: true, index: true
+
+      table.timestamps
+    end
+    add_index :oauth_sessions, :access_token_jti, unique: true
+    add_index :oauth_sessions, :refresh_token_jti, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_28_195628) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_29_150719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "oauth_session_status", ["created", "expired", "refreshed", "revoked"]
 
   create_table "authorization_grants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "code_challenge", null: false
@@ -28,6 +32,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_195628) do
     t.index ["user_id"], name: "index_authorization_grants_on_user_id"
   end
 
+  create_table "oauth_sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "access_token_jti", null: false
+    t.string "refresh_token_jti", null: false
+    t.enum "status", default: "created", null: false, enum_type: "oauth_session_status"
+    t.uuid "authorization_grant_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["access_token_jti"], name: "index_oauth_sessions_on_access_token_jti", unique: true
+    t.index ["authorization_grant_id"], name: "index_oauth_sessions_on_authorization_grant_id"
+    t.index ["refresh_token_jti"], name: "index_oauth_sessions_on_refresh_token_jti", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
@@ -38,4 +54,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_195628) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "oauth_sessions", "authorization_grants"
 end

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -30,4 +30,8 @@ module OAuth
   ##
   # Error for when client provides a param that fails validation.
   class InvalidRequestError < StandardError; end
+
+  ##
+  # Error for when server experiences an error.
+  class ServerError < StandardError; end
 end

--- a/spec/factories/oauth_sessions.rb
+++ b/spec/factories/oauth_sessions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :oauth_session do
+    access_token_jti { SecureRandom.uuid }
+    refresh_token_jti { SecureRandom.uuid }
+    status { 'created' }
+    authorization_grant
+  end
+end

--- a/spec/models/authorization_grant_spec.rb
+++ b/spec/models/authorization_grant_spec.rb
@@ -40,5 +40,6 @@ RSpec.describe AuthorizationGrant do
 
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:oauth_sessions) }
   end
 end

--- a/spec/models/oauth_session_spec.rb
+++ b/spec/models/oauth_session_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
+  subject(:model) { build(:oauth_session) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:access_token_jti) }
+    it { is_expected.to validate_uniqueness_of(:access_token_jti) }
+    it { is_expected.to allow_value(SecureRandom.uuid).for(:access_token_jti) }
+    it { is_expected.not_to allow_value('foobar').for(:access_token_jti) }
+
+    it { is_expected.to validate_presence_of(:refresh_token_jti) }
+    it { is_expected.to validate_uniqueness_of(:refresh_token_jti) }
+    it { is_expected.to allow_value(SecureRandom.uuid).for(:refresh_token_jti) }
+    it { is_expected.not_to allow_value('foobar').for(:refresh_token_jti) }
+
+    it { is_expected.to allow_value('created').for(:status) }
+    it { is_expected.to allow_value('expired').for(:status) }
+    it { is_expected.to allow_value('refreshed').for(:status) }
+    it { is_expected.to allow_value('revoked').for(:status) }
+
+    it 'raises an ArgumentError when an invalid status is provided' do
+      expect { model.status = 'foobar' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:authorization_grant) }
+  end
+end

--- a/spec/services/oauth_token_encoder_service_spec.rb
+++ b/spec/services/oauth_token_encoder_service_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OAuthTokenEncoderService do # rubocop:disable RSpec/FilePath
+  describe '.call' do
+    subject(:service_call) do
+      described_class.new(client_id:, expiration:, optional_claims:).call
+    end
+
+    let(:client_id) { 'democlient' }
+    let(:expiration) { 5.minutes.from_now }
+    let(:optional_claims) { {} }
+
+    context 'with invalid client_id provided' do
+      let(:client_id) { nil }
+
+      it 'raises an OAuth::ServerError' do
+        expect { service_call }.to raise_error(
+          OAuth::ServerError, I18n.t('services.oauth_token_encoder_service.invalid_client_id', value: client_id)
+        )
+      end
+    end
+
+    context 'with invalid expiration provided' do
+      let(:expiration) { 5.minutes.from_now.to_s }
+
+      it 'raises an OAuth::ServerError' do
+        expect { service_call }.to raise_error(
+          OAuth::ServerError, I18n.t('services.oauth_token_encoder_service.invalid_expiration', value: expiration)
+        )
+      end
+    end
+
+    context 'with valid params provided' do
+      it 'returns a valid JWT token' do
+        expect(service_call.token).to match(/\A[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\z/)
+      end
+
+      it 'returns a token with a valid aud claim' do
+        token = JsonWebToken.decode(service_call.token)
+        expect(token[:aud]).to eq(client_id)
+      end
+
+      it 'returns a token with a valid exp claim' do
+        token = JsonWebToken.decode(service_call.token)
+        expect(token[:exp]).to eq(expiration.to_i)
+      end
+
+      it 'returns a token with a valid iat claim' do
+        token = JsonWebToken.decode(service_call.token)
+        expect(token[:iat]).to be_a(Integer)
+      end
+
+      it 'returns a token with a valid iss claim' do
+        token = JsonWebToken.decode(service_call.token)
+        expect(token[:iss]).to eq(Rails.configuration.oauth.issuer_url)
+      end
+
+      it 'returns a token with a valid jti claim' do
+        token = JsonWebToken.decode(service_call.token)
+        expect(token[:jti]).to match(OAuthSession::VALID_UUID_REGEX)
+      end
+
+      it 'returns jti which matches the jti in the token' do
+        jti, token = service_call.deconstruct
+        parsed_token = JsonWebToken.decode(token)
+        expect(jti).to match(parsed_token[:jti])
+      end
+
+      context 'with optional claims provided' do
+        let(:optional_claims) { { foo: 'bar' } }
+
+        it 'returns a token with the optional claims provided' do
+          token = JsonWebToken.decode(service_call.token)
+          expect(token[:foo]).to eq('bar')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR implements access and refresh token generation for the `/token` endpoint. I decided to use JWT's for both tokens; however, the refresh token is generated with a minimal set of claims. I noticed that `vets-api` uses an encrypted string that is split into different segments containing information about the refresh token, but I didn't see that as being functionally different than simply using a JWT. I could be mistaken, though, so please let me know if there is something that I'm missing that led to that design decision.

I implemented an `OAuthSession` model that stores the JTI for an access token and the JTI for a refresh token as well as the status for the token pair. The JTI's are stored as encrypted strings which will be used to look up the `OAuthSession` record when provided a token. Both columns are indexed, allowing for quick retrieval and ensuring their uniqueness in the DB. I opted to forgo adding additional columns since the JWT's themselves contain the claims used for validation (`exp`, `iss`, `aud`, etc.). This approach has the benefit of being able to track the state of a token pair while storing only the minimal set of data necessary to do so. While the JTI's themselves don't seem particularly sensitive, I opted to use ActiveRecord encryption to store them securely anyways.

The possible values for the status column are 'created', 'expired', 'revoked', and 'refreshed'; the status is defaulted to 'created' on creation, and future iterations will add functionality that will update the status column to the other values. For example, when the `/refresh` token is implemented, a service object will create a new `OAuthSession` and set the status column for the original `OAuthSession` to 'refreshed'. When the `/revoke` endpoint is implemented, a service object will set the status column to 'revoked' for the `OAuthSession`. A service object will check the `exp` claim for the provided token (access token or refresh token depending on the endpoint) and update the status column to 'expired' for each of the `/refresh`, `/revoke`, and `/introspect` endpoints.

The `OAuthSession` record is tied to an `AuthorizationGrant` record, which can have many `OAuthSessions`. An `AuthorizationGrant` is marked as redeemed the first time its code is used to generate a token pair. Future changes will include updating its dependent `OAuthSession` records' status to 'revoked' if its code is reused when it has already been redeemed.

I implemented an `OAuthTokenEncoderService` that is used to generate both the access and refresh tokens. It accepts the `client_id` from the authorization grant to be used as the `aud` claim, an `expiration` date for the `exp` claim (5 minutes for access token and 14 days for refresh token), and an `optional_claims` hash. The optional claims hash is used for access token generation as it will contain additional claims about the user to be added to the token. This service returns the JTI for the token created as well as the token itself. The JTI value is stored in the `OAuthSession` record, and the tokens are rendered in a JSON response to the client.


## Testing

* Ensure the user is signed in.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Enter the authorization code at the prompt in the manual testing script.
* Verify the response body is a JSON response structured as such:
```
{
  "access_token": [Access Token],
  "refresh_token": [Refresh Token],
  "token_type": "bearer",
  "expires_in": [5 minutes in the future from the time of request (UNIX time)]
}
```
* Open the rails console.
* Decode the access token: `JsonWebToken.decode("[Access Token]")`
* Verify the token hash is structured as:
```
{
  "aud" => "democlient",
  "iat" => [Time of request (UNIX time)],
  "iss" => "http://localhost:3000/",
  "jti" => [Generated UUID],
  "user_id" => [The user_id associated with the authorization grant redeemed],
  "exp" => [5 minutes in the future from the time of request (UNIX time)]
}
```
* Ensure that the `exp` claim matches the `expires_in` value for the response to the client.
* Decode the refresh token: `JsonWebToken.decode("[Refresh Token]")`
* Verify the token hash is structured as:
```
{
  "aud" => "democlient",
  "iat" => [Time of request (UNIX time)],
  "iss" => "http://localhost:3000/",
  "jti" => [Generated UUID],
  "exp" => [14 days in the future from the time of request (UNIX time)]
}
```
* Retrieve the original `AuthorizationGrant` record from the authorization code
```
authorization_grant = AuthorizationGrant.find("[Authorization Code]")
```
* Verify the `redeemed` status is set to true.
* Retrieve the `OAuthSession` record. You can do this a couple different ways; it might make sense to try them all to ensure each method of retrieval works:
  * `authorization_grant.oauth_sessions.last`
  * `OAuthSession.find_by(access_token_jti: [Access Token JTI])`
  * `OAuthSession.find_by(refresh_token_jti: [Refresh Token JTI])`
* Verify the `OAuthSession` record has the correct access token and refresh token JTI's saved.
* Verify the `OAuthSession` is linked to the original `AuthorizationGrant` record.
* Verify the status is 'created'
