### PR TITLE
[TAS-15] Implement user info endpoint

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -11,6 +11,8 @@ directories:
       enabled: false
     InstanceVariableAssumption:
       enabled: false
+    UncommunicativeModuleName:
+      enabled: false
   "app/helpers":
     IrresponsibleModule:
       enabled: false
@@ -45,6 +47,7 @@ detectors:
   TooManyStatements:
     exclude:
       - OAuthController#authorize
+      - OAuthController#token
       - ClientRedirectUrlService#call
       - StateTokenEncoderService#initialize
       - AuthorizationGrantsController#create

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,8 @@ gem 'stimulus-rails'
 gem 'tailwindcss-rails'
 
 # Use for performant serialization
-gem 'jsonapi-serializer'
+gem 'blueprinter'
+gem 'oj'
 
 # Use jwt for tokens
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     bcrypt (3.1.19)
     benchmark (0.2.1)
     bindex (0.8.1)
+    blueprinter (0.25.3)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -105,8 +106,6 @@ GEM
       reline (>= 0.3.6)
     jaro_winkler (1.5.6)
     json (2.6.3)
-    jsonapi-serializer (2.2.0)
-      activesupport (>= 4.2)
     jwt (2.7.1)
     kramdown (2.4.0)
       rexml
@@ -141,6 +140,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
+    oj (3.16.1)
     overcommit (0.60.0)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
@@ -306,13 +306,14 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
+  blueprinter
   bootsnap
   debug
   factory_bot_rails
   faker
   importmap-rails
-  jsonapi-serializer
   jwt
+  oj
   overcommit
   pg (~> 1.1)
   puma (~> 5.0)

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+##
+# Serializes user objects
+class UserBlueprint < Blueprinter::Base
+  fields :first_name, :last_name, :email
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    ##
+    # API controller for user resources
+    class UsersController < API::BaseController
+      # GET /api/v1/users/current
+      def current
+        user = user_from_token
+        render json: UserBlueprint.render(user), status: :ok
+      end
+    end
+  end
+end

--- a/config/initializers/blueprinter.rb
+++ b/config/initializers/blueprinter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'oj'
+
+Blueprinter.configure do |config|
+  config.generator = Oj
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,4 +15,5 @@
 # These inflection rules are supported but not enabled by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'OAuth'
+  inflect.acronym 'API'
 end

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'oj'
+
+Oj.optimize_rails

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -1,0 +1,6 @@
+en:
+  api:
+    errors:
+      missing_auth_header_response: 'A valid access token must be provided in the AUTHORIZATION header of the request.'
+      invalid_token_response: 'An invalid access token was provided.'
+      unauthorized_token_response: 'An unauthorized access token was provided.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,13 @@ Rails.application.routes.draw do
 
   resources :authorization_grants, path: 'authorization-grants', only: %i[new create]
 
+  namespace :api, format: :json do
+    namespace :v1 do
+      scope :users do
+        get 'current', to: 'users#current', as: :current_user
+      end
+    end
+  end
+
   root 'demo_client#index'
 end

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -34,4 +34,16 @@ module OAuth
   ##
   # Error for when server experiences an error.
   class ServerError < StandardError; end
+
+  ##
+  # Error for when an authorization header is not provided.
+  class MissingAuthorizationHeaderError < StandardError; end
+
+  ##
+  # Error for when an invalid access token is provided.
+  class InvalidAccessTokenError < StandardError; end
+
+  ##
+  # Error for when an unauthorized access token is provided.
+  class UnauthorizedAccessTokenError < StandardError; end
 end

--- a/script/manual_testing.rb
+++ b/script/manual_testing.rb
@@ -23,6 +23,7 @@ puts <<~TEXT
   The client used by this test script has the following credentials:
   client_id: #{client_id}
   client_secret: #{client_secret}
+
 TEXT
 
 puts 'Authorization code? -> '
@@ -41,5 +42,18 @@ response = Net::HTTP.start(uri.hostname, uri.port) do |http|
   http.request(request)
 end
 
-puts response.body
-# puts "Access token: #{response.body['access_token']}"
+parsed_response = JSON.parse(response.body)
+
+puts <<~TEXT
+
+  Access token:
+  #{parsed_response['access_token']}
+
+  Refresh token:
+  #{parsed_response['refresh_token']}
+
+  Token type: #{parsed_response['token_type']}
+  Expires in: #{parsed_response['expires_in']}
+
+  #{response.body}
+TEXT

--- a/spec/blueprints/user_blueprint_spec.rb
+++ b/spec/blueprints/user_blueprint_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserBlueprint do
+  describe '.render' do
+    subject(:serialized_data) { described_class.render(user) }
+
+    let(:user) { create(:user) }
+
+    it 'renders the fields' do
+      expect(JSON.parse(serialized_data)).to eq(
+        {
+          'first_name' => user.first_name,
+          'last_name' => user.last_name,
+          'email' => user.email
+        }
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::UsersController do
+  describe 'GET /current' do
+    let(:params) { {} }
+    let(:headers) { {} }
+    let(:user) { create(:user) }
+
+    include_context 'with a valid access token', :get, :api_v1_current_user_path
+
+    it_behaves_like 'an endpoint that requires token authentication'
+
+    it 'renders a successful response' do
+      call_endpoint
+      expect(response).to be_successful
+    end
+
+    it 'renders the serialized data' do
+      allow(UserBlueprint).to receive(:render)
+      call_endpoint
+      expect(UserBlueprint).to have_received(:render).with(user)
+    end
+  end
+end

--- a/spec/routing/api/v1/users_routing_spec.rb
+++ b/spec/routing/api/v1/users_routing_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::UsersController do
+  describe 'routing' do
+    it 'routes to #current' do
+      expect(get: '/api/v1/users/current').to route_to(controller: 'api/v1/users', action: 'current')
+    end
+  end
+end

--- a/spec/support/shared/token_authentication.rb
+++ b/spec/support/shared/token_authentication.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an endpoint that requires token authentication' do
+  context 'without an AUTHORIZATION header' do
+    before do
+      shared_context_headers.delete('AUTHORIZATION')
+    end
+
+    it 'responds with HTTP status unauthorized' do
+      call_endpoint
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'without a valid JWT in the AUTHORIZATION header' do
+    before do
+      shared_context_headers['AUTHORIZATION'] = 'foobar'
+    end
+
+    it 'responds with HTTP status unauthorized' do
+      call_endpoint
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'with an access token with invalid claims in the AUTHORIZATION header' do
+    let(:oauth_session) { create(:oauth_session, authorization_grant:) }
+    let(:authorization_grant) { create(:authorization_grant, user:) }
+
+    before do
+      _, token = OAuthTokenEncoderService.call(
+        client_id: 'democlient',
+        expiration: 5.minutes.ago,
+        optional_claims: { user_id: user.id, jti: oauth_session.access_token_jti }
+      ).deconstruct
+      shared_context_headers['AUTHORIZATION'] = token
+    end
+
+    it 'responds with HTTP status unauthorized' do
+      call_endpoint
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end
+
+RSpec.shared_context 'with a valid access token' do |method, path|
+  subject(:call_endpoint) { send(method, url, **options_for_request) }
+
+  let(:url) { send(path) }
+  let(:options_for_request) { { params: shared_context_params, headers: shared_context_headers } }
+  let(:shared_context_params) { params }
+  let(:shared_context_headers) { headers.reverse_merge!(bearer_token_header) }
+
+  let(:authorization_grant) { create(:authorization_grant, user:) }
+  let(:oauth_session) { create(:oauth_session, authorization_grant:) }
+
+  def bearer_token_header
+    _, token = OAuthTokenEncoderService.call(
+      client_id: 'democlient',
+      expiration: Rails.configuration.oauth.access_token_expiration.minutes.from_now,
+      optional_claims: { user_id: user.id, jti: oauth_session.access_token_jti }
+    ).deconstruct
+
+    { 'AUTHORIZATION' => "Bearer #{token}" }
+  end
+end


### PR DESCRIPTION
## Description

This PR implements the `/api/v1/users/current` endpoint which provides user information for a given access token. As part of this, I implemented a base API controller with a mechanism for token authentication.

Note: I'm trying out `blueprinter` and `oj` for serializing the JSON responses; I haven't used either project before and wanted to give them a shot.

## Testing

### Missing authorization header
* Open the Postman collection.
[![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/dick-davis/workspace/oauth-flow-demo/request/666655-4e29e209-13bb-432a-98d0-6375e266828c?action=share&creator=666655&ctx=documentation&active-environment=666655-68a62af8-6b4f-41c9-aacb-a6ab116b78cd)
* If necessary, add the `host` variable to the Local Development environment with value `http://localhost:3000`.
* Navigate to the Authorization tab of the OAuth Flow Demo folder, change the type to 'No Auth', and save it.
* Expand the OAuth Flow Demo folder and send the `/api/v1/users/current` request.
* Verify the response has HTTP status 401.
* Verify the response body is a JSON object containing the error message 'A valid access token must be provided in the AUTHORIZATION header of the request'.
* Navigate to the Authorization tab of the OAuth Flow Demo folder, change the type back to 'Bearer Token', set the value for token to `{{bearer_token}}`, and save it.

### Invalid access token
* Open the Postman collection.
[![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/dick-davis/workspace/oauth-flow-demo/request/666655-4e29e209-13bb-432a-98d0-6375e266828c?action=share&creator=666655&ctx=documentation&active-environment=666655-68a62af8-6b4f-41c9-aacb-a6ab116b78cd)
* If necessary, add the `host` variable to the Local Development environment with value `http://localhost:3000`.
* Add the `bearer_token` variable to the Local Development environment with any value that doesn't correspond to a valid JWT.
* Expand the OAuth Flow Demo folder and send the `/api/v1/users/current` request.
* Verify the response has HTTP status 401.
* Verify the response body is a JSON object containing the error message 'An invalid access token was provided'.

### Unauthorized access token

* Ensure the user is signed in.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Enter the authorization code at the prompt in the manual testing script.
* Copy the access token from the response.
* Either wait 5 minutes before proceeding, or decode the token in a Rails console, manipulate the `exp` claim to be expired, and then encode the token again.
* Open the Postman collection.
[![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/dick-davis/workspace/oauth-flow-demo/request/666655-4e29e209-13bb-432a-98d0-6375e266828c?action=share&creator=666655&ctx=documentation&active-environment=666655-68a62af8-6b4f-41c9-aacb-a6ab116b78cd)
* If necessary, add the `host` variable to the Local Development environment with value `http://localhost:3000`.
* Add the `bearer_token` variable to the Local Development environment and paste in the access token for the value.
* Expand the OAuth Flow Demo folder and send the `/api/v1/users/current` request.
* Verify the response has HTTP status 401.
* Verify the response body is a JSON object containing the error message 'An unauthorized access token was provided.'.

### Happy path

* Ensure the user is signed in.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Enter the authorization code at the prompt in the manual testing script.
* Copy the access token from the response.
* Open the Postman collection.
[![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/dick-davis/workspace/oauth-flow-demo/request/666655-4e29e209-13bb-432a-98d0-6375e266828c?action=share&creator=666655&ctx=documentation&active-environment=666655-68a62af8-6b4f-41c9-aacb-a6ab116b78cd)
* If necessary, add the `host` variable to the Local Development environment with value `http://localhost:3000`.
* Add the `bearer_token` variable to the Local Development environment and paste in the access token for the value.
* Expand the OAuth Flow Demo folder and send the `/api/v1/users/current` request.
* Verify the response has HTTP status 200.
* Verify the response body is a JSON object containing the first name, last name, and email address of the user.

<details>
<summary>Screenshots</summary>

Add screenshots here.
</details>
