### PR TITLE
[TAS-57] Implement access token model

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -25,6 +25,8 @@ directories:
   "app/models":
     InstanceVariableAssumption:
       enabled: false
+    Attribute:
+      enabled: false
   "app/services":
     UtilityFunction:
       enabled: false
@@ -55,3 +57,6 @@ detectors:
     exclude:
       - ClientAuthentication#http_basic_auth_successful?
       - AuthorizationGrantsController#create
+  DuplicateMethodCall:
+    exclude:
+      - AccessToken#valid_exp?

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+##
+# Models an access token
+class AccessToken
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
+
+  OAUTH_CONFIG = Rails.configuration.oauth.freeze
+  REVOCABLE_CLAIMS = %i[aud iss user_id].freeze
+  EXPIRABLE_CLAIMS = %i[exp].freeze
+
+  attr_accessor :aud, :exp, :iat, :iss, :jti, :user_id
+
+  validates :jti, presence: true
+  validate do
+    errors.add(:jti, 'Invalid `jti` claim provided') unless oauth_session&.created_status?
+  end
+
+  validates :aud, presence: true, format: { with: /\A#{OAUTH_CONFIG.audience_url}*/ }
+
+  validates :exp, presence: true
+  validate do
+    next if exp.blank?
+
+    errors.add(:exp, 'is expired') if Time.zone.now > Time.zone.at(exp)
+  end
+
+  validates :iss, presence: true, format: { with: /\A#{OAUTH_CONFIG.issuer_url}\z/ }
+
+  validates :user_id, presence: true, comparison: { equal_to: :user_id_from_oauth_session }
+
+  after_validation :expire_oauth_session, if: :errors_for_expirable_claims?
+  after_validation :revoke_oauth_session, if: :errors_for_revocable_claims?
+
+  private
+
+  def oauth_session
+    return @oauth_session if defined?(@oauth_session)
+
+    @oauth_session = OAuthSession.find_by(access_token_jti: jti)
+  end
+
+  def user_id_from_oauth_session
+    oauth_session&.user_id
+  end
+
+  def errors_for_revocable_claims?
+    return false if skip_oauth_session_update?
+
+    errors.attribute_names.intersect?(REVOCABLE_CLAIMS)
+  end
+
+  def revoke_oauth_session
+    oauth_session.update(status: 'revoked')
+  end
+
+  def errors_for_expirable_claims?
+    return false if skip_oauth_session_update?
+
+    errors.attribute_names.intersect?(EXPIRABLE_CLAIMS)
+  end
+
+  def expire_oauth_session
+    oauth_session.update(status: 'expired')
+  end
+
+  def skip_oauth_session_update?
+    errors.blank? || errors.include?(:jti)
+  end
+end

--- a/app/models/oauth_session.rb
+++ b/app/models/oauth_session.rb
@@ -12,6 +12,8 @@ class OAuthSession < ApplicationRecord
 
   VALID_UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/i
 
+  delegate :user_id, to: :authorization_grant
+
   validates :access_token_jti, presence: true, uniqueness: true, format: { with: VALID_UUID_REGEX }
   encrypts :access_token_jti, deterministic: true
 

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -11,7 +11,12 @@ module JsonWebToken
   end
 
   def self.decode(token)
-    (payload,) = JWT.decode(token, Rails.application.credentials.secret_key_base)
+    (payload,) = JWT.decode(
+      token,
+      Rails.application.credentials.secret_key_base,
+      true,
+      { verify_expiration: false, algorithm: 'HS256' }
+    )
     ActiveSupport::HashWithIndifferentAccess.new(payload)
   end
 end

--- a/spec/factories/access_tokens.rb
+++ b/spec/factories/access_tokens.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :access_token, class: 'AccessToken' do
+    transient do
+      oauth_session { association(:oauth_session) }
+    end
+
+    aud { Rails.configuration.oauth[:audience_url] }
+    exp { 5.minutes.from_now.to_i }
+    iat { Time.zone.now.to_i }
+    iss { Rails.configuration.oauth[:issuer_url] }
+    jti { oauth_session.access_token_jti }
+    user_id { oauth_session.user_id }
+
+    initialize_with { new(aud:, exp:, iat:, iss:, jti:, user_id:) }
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccessToken do
+  subject(:model) { build(:access_token, oauth_session:) }
+
+  let(:oauth_session) { create(:oauth_session, authorization_grant:) }
+  let(:authorization_grant) { create(:authorization_grant, user:) }
+  let(:user) { create(:user) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:aud) }
+    it { is_expected.not_to allow_value('http://foo.bar/api').for(:aud) }
+
+    it { is_expected.to validate_presence_of(:exp) }
+    it { is_expected.not_to allow_value(5.minutes.ago.to_i).for(:exp) }
+
+    it { is_expected.to validate_presence_of(:iss) }
+    it { is_expected.not_to allow_value('http://foo.bar/').for(:iss) }
+
+    it { is_expected.to validate_presence_of(:jti) }
+    it { is_expected.not_to allow_value('does-not-map-to-oauth-session').for(:jti) }
+
+    it { is_expected.to validate_presence_of(:user_id) }
+
+    it 'adds an error if the provided `user_id` claim does not map to the original authorization grant' do
+      other_user = create(:user)
+      model.user_id = other_user.id
+      model.valid?
+      expect(model.errors).to include(:user_id)
+    end
+
+    it 'does not add any errors if all provided claims are valid' do
+      expect(model).to be_valid
+    end
+  end
+
+  describe 'callbacks' do
+    describe '#revoke_oauth_session' do
+      context 'when the `aud` claim is invalid' do
+        it 'updates the OAuthSession status to `revoked`' do
+          model.aud = ''
+          expect do
+            model.valid?
+            oauth_session.reload
+          end.to change(oauth_session, :status).from('created').to('revoked')
+        end
+      end
+
+      context 'when the `iss` claim is invalid' do
+        it 'updates the OAuthSession status to `revoked`' do
+          model.iss = ''
+          expect do
+            model.valid?
+            oauth_session.reload
+          end.to change(oauth_session, :status).from('created').to('revoked')
+        end
+      end
+
+      context 'when the `exp` claim is invalid' do
+        it 'does not update the OAuthSession status to `revoked`' do
+          model.exp = ''
+          model.valid?
+          expect(oauth_session.reload).not_to be_revoked_status
+        end
+      end
+
+      context 'when the `jti` claim is invalid' do
+        it 'does not update the OAuthSession status to `revoked`' do
+          model.jti = ''
+          model.valid?
+          expect(oauth_session.reload).not_to be_revoked_status
+        end
+      end
+
+      context 'when the `user_id` claim is invalid' do
+        it 'updates the OAuthSession status to `revoked`' do
+          model.user_id = ''
+          expect do
+            model.valid?
+            oauth_session.reload
+          end.to change(oauth_session, :status).from('created').to('revoked')
+        end
+      end
+    end
+
+    describe '#expire_oauth_session' do
+      context 'when the `exp` claim is blank' do
+        it 'updates the OAuthSession status to `expired`' do
+          model.exp = ''
+          expect do
+            model.valid?
+            oauth_session.reload
+          end.to change(oauth_session, :status).from('created').to('expired')
+        end
+      end
+
+      context 'when the `exp` claim is expired' do
+        it 'updates the OAuthSession status to `expired`' do
+          model.exp = 5.minutes.ago.to_i
+          expect do
+            model.valid?
+            oauth_session.reload
+          end.to change(oauth_session, :status).from('created').to('expired')
+        end
+      end
+
+      context 'when the `exp` is invalid and a revocable claim is also invalid' do
+        it 'does not update the OAuthSession status to `expired`' do
+          model.exp = ''
+          model.aud = ''
+          model.valid?
+          expect(oauth_session.reload).not_to be_expired_status
+        end
+
+        it 'updates the OAuthSession status to `revoked`' do
+          model.exp = ''
+          model.aud = ''
+          expect do
+            model.valid?
+            oauth_session.reload
+          end.to change(oauth_session, :status).from('created').to('revoked')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR implements an `AccessToken` model for validating claims in a decoded access token provided by a client. It ensures that the token claims are validated as follows:

* `aud`: must be present and match the configured audience URL (all routes under the `/api` namespace)
* `iss`: must be present and match the configured issuer URL (`http://localhost:3000`)
* `exp`: must be present and in the future
* `jti`: must be present and map to an `OAuthSession` record that is in `created` status.
* `user_id`: must be present and match the `user_id` of the original `AuthorizationGrant` record tied to the associated `OAuthSession` record.

If validations fail, the associated `OAuthSession` record status is updated as follows:
  * if the `jti` claim is invalid, the status should not be updated since there is no associated `OAuthSession` record found.
  * if the `exp` claim is invalid, the status should be updated to `expired`.
  * if the `aud`, `iss`, or `user_id` claims are invalid, the status should be updated to `revoked`.

## Testing

Unit tests should be sufficient for this effort. If desired, you can run through the following steps to test it manually:

* Ensure the user is signed in.
* Execute the manual testing script by using the following command: `bin/rails r script/manual_testing.rb`
* Copy the URL generated by the script and enter it in your browser.
* The first time you access it, you should get a browser prompt for the HTTP Basic auth credentials; the credentials will be displayed in the script output, so copy/paste them in.
* Click Approve.
* Copy the authorization code from the query params in the redirect URL.
* Enter the authorization code at the prompt in the manual testing script.
* Copy the access token from the response.
* Open a Rails console.
* Decode the access token: `token = JsonWebToken.decode("[Access Token]")`
* Manipulate the claims: `token[:exp] = 5.minutes.ago.to_i`
* Initialize a new `AccessToken` instance with the decoded token hash: `access_token = AccessToken.new(token)`
* Call `valid?` on it: `access_token.valid?`
* Verify the expected errors are displayed.
* Find the associated `OauthSession` record: `oauth_session = OAuthSession.find_by(access_token_jti: token[:jti])`
* Verify the associated `OAuthSession` status record is updated as expected
  * if the `exp` claim is invalid, the status should be updated to `expired`
  * if the `aud`, `iss`, or `user_id` claims are invalid, the status should be updated to `revoked`
  * if the `jti` claim is invalid, the status should not be updated
  * if there are no errors, the status should not be updated

