### PR TITLE
[TAS-16] Implement refresh endpoint

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -52,6 +52,7 @@ detectors:
       - OAuth::AuthorizationsController#authorize
       - OAuth::SessionsController#token
       - OAuthSessionCreatable#create_oauth_session
+      - OAuthSession#refresh
       - SessionsController#create
       - SessionsController#url_for_sign_in_redirect
       - StateTokenEncoderService#initialize

--- a/app/controllers/oauth/sessions_controller.rb
+++ b/app/controllers/oauth/sessions_controller.rb
@@ -34,6 +34,8 @@ module OAuth
       render_token_request_error(error: 'invalid_grant')
     end
 
+    def refresh; end
+
     private
 
     def validate_grant_type

--- a/config/locales/oauth/en.yml
+++ b/config/locales/oauth/en.yml
@@ -5,3 +5,5 @@ en:
       lede: 'The request provided by the client to this server is malformed. Please report this error through the client support channel.'
     server_error:
       oauth_session_failure: 'Failed to create OAuthSession. Errors: %{errors}'
+    mismatched_refresh_token_error: 'The provided refresh token JTI does not match the refresh token JTI of the target OAuthSession.'
+    revoked_session_error: 'Refresh token replay attack detected. Refreshed OAuthSession: %{refreshed_session_id}, Revoked OAuthSession: %{revoked_session_id}, Client ID: %{client_id}, User ID: %{user_id}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+##
+# Provides a route constraint for when the grant type is 'refresh_token'
+GrantTypeConstraint = Struct.new(:grant_type) do
+  def matches?(request)
+    request.request_parameters['grant_type'] == grant_type
+  end
+end
+
 Rails.application.routes.draw do
   resources :users, only: %i[new create]
 
@@ -9,6 +17,7 @@ Rails.application.routes.draw do
 
   namespace :oauth do
     get 'authorize', to: 'authorizations#authorize'
+    post 'token', to: 'sessions#refresh', constraints: GrantTypeConstraint.new('refresh_token'), as: :refresh
     post 'token', to: 'sessions#token'
   end
 

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -50,4 +50,22 @@ module OAuth
   ##
   # Error for when an unauthorized access token is provided.
   class UnauthorizedAccessTokenError < StandardError; end
+
+  ##
+  # Error for when an OAuthSession is revoked.
+  class RevokedSessionError < StandardError
+    attr_reader :client_id, :refreshed_session_id, :revoked_session_id, :user_id
+
+    def initialize(client_id:, refreshed_session_id:, revoked_session_id:, user_id:)
+      super()
+      @client_id = client_id
+      @refreshed_session_id = refreshed_session_id
+      @revoked_session_id = revoked_session_id
+      @user_id = user_id
+    end
+
+    def message
+      I18n.t('oauth.revoked_session_error', client_id:, refreshed_session_id:, revoked_session_id:, user_id:)
+    end
+  end
 end

--- a/spec/models/oauth_session_spec.rb
+++ b/spec/models/oauth_session_spec.rb
@@ -29,4 +29,165 @@ RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
   describe 'associations' do
     it { is_expected.to belong_to(:authorization_grant) }
   end
+
+  describe '#refresh' do
+    subject(:method_call) { oauth_session.refresh(token: refresh_token) }
+
+    let!(:oauth_session) { create(:oauth_session, authorization_grant:) }
+    let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
+    let(:refresh_token) { build(:refresh_token, oauth_session:) }
+
+    it_behaves_like 'a model that creates OAuth sessions'
+
+    context 'when the oauth session is in created status' do
+      it 'updates the status attribute to refreshed' do
+        expect { method_call }.to change(oauth_session, :status).from('created').to('refreshed')
+      end
+
+      it 'creates a new oauth session' do
+        expect { method_call }.to change(described_class, :count).by(1)
+      end
+    end
+
+    context 'when the provided token contains a JTI that does not match the refresh token JTI of the oauth session' do
+      let(:refresh_token) { build(:refresh_token, oauth_session:, jti: 'foobar') }
+
+      it 'raises an OAuth::ServerError' do
+        expect { method_call }.to raise_error(OAuth::ServerError, I18n.t('oauth.mismatched_refresh_token_error'))
+      end
+
+      it 'does not create a new oauth session' do
+        begin
+          method_call
+        rescue OAuth::ServerError
+          nil
+        end
+        expect(described_class.count).to eq(1)
+      end
+    end
+
+    context 'when the provided token has invalid claims' do
+      let(:refresh_token) { build(:refresh_token, oauth_session:, exp: 14.days.ago.to_i) }
+
+      it 'raises an OAuth::InvalidGrantError' do
+        expect { method_call }.to raise_error(OAuth::InvalidGrantError)
+      end
+
+      it 'does not create a new oauth session' do
+        begin
+          method_call
+        rescue OAuth::InvalidGrantError
+          nil
+        end
+        expect(described_class.count).to eq(1)
+      end
+    end
+
+    context 'when the oauth session has already been refreshed' do
+      let!(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'refreshed') }
+
+      context 'with an active oauth session existing for authorization grant' do
+        it 'revokes the active oauth session' do
+          active_oauth_session = create(:oauth_session, authorization_grant:)
+          expect do
+            method_call
+          rescue OAuth::RevokedSessionError
+            active_oauth_session.reload
+          end.to change(active_oauth_session, :status).from('created').to('revoked')
+        end
+
+        it 'raises an OAuth::RevokedSessionError' do
+          create(:oauth_session, authorization_grant:)
+          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+        end
+
+        it 'does not create a new oauth session' do
+          create(:oauth_session, authorization_grant:)
+          begin
+            method_call
+          rescue OAuth::RevokedSessionError
+            nil
+          end
+          expect(described_class.count).to eq(2)
+        end
+      end
+
+      context 'without an active oauth session existing for authorization grant' do
+        it 'changes its own status to revoked' do
+          expect do
+            method_call
+          rescue OAuth::RevokedSessionError
+            nil
+          end.to change(oauth_session, :status).from('refreshed').to('revoked')
+        end
+
+        it 'raises an OAuth::RevokedSessionError' do
+          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+        end
+
+        it 'does not create a new oauth session' do
+          begin
+            method_call
+          rescue OAuth::RevokedSessionError
+            nil
+          end
+          expect(described_class.count).to eq(1)
+        end
+      end
+    end
+
+    context 'when the oauth session has already been revoked' do
+      let!(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'revoked') }
+
+      context 'with an active oauth session existing for authorization grant' do
+        it 'revokes the active oauth session' do
+          active_oauth_session = create(:oauth_session, authorization_grant:)
+          expect do
+            method_call
+          rescue OAuth::RevokedSessionError
+            active_oauth_session.reload
+          end.to change(active_oauth_session, :status).from('created').to('revoked')
+        end
+
+        it 'raises an OAuth::RevokedSessionError' do
+          create(:oauth_session, authorization_grant:)
+          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+        end
+
+        it 'does not create a new oauth session' do
+          create(:oauth_session, authorization_grant:)
+          begin
+            method_call
+          rescue OAuth::RevokedSessionError
+            nil
+          end
+          expect(described_class.count).to eq(2)
+        end
+      end
+
+      context 'without an active oauth session existing for authorization grant' do
+        it 'keeps its own status as revoked' do
+          begin
+            method_call
+          rescue OAuth::RevokedSessionError
+            nil
+          end
+          expect(oauth_session.reload).to be_revoked_status
+        end
+
+        it 'raises an OAuth::RevokedSessionError' do
+          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+        end
+
+        it 'does not create a new oauth session' do
+          begin
+            method_call
+          rescue OAuth::RevokedSessionError
+            nil
+          end
+          expect(described_class.count).to eq(1)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/oauth/sessions_controller_spec.rb
+++ b/spec/requests/oauth/sessions_controller_spec.rb
@@ -123,4 +123,155 @@ RSpec.describe OAuth::SessionsController do # rubocop:disable RSpec/FilePath
       end
     end
   end
+
+  describe 'POST /token (grant_type="refresh_token")' do
+    let(:headers) { {} }
+    let(:params) { { grant_type:, refresh_token: } }
+    let(:grant_type) { 'refresh_token' }
+    let(:refresh_token) { JsonWebToken.encode(attributes_for(:refresh_token, oauth_session:)) }
+    let!(:oauth_session) { create(:oauth_session, authorization_grant:) }
+    let(:authorization_grant) { create(:authorization_grant, user:) }
+    let(:user) { create(:user) }
+
+    let(:oauth_token_encoder_service) { instance_double(OAuthTokenEncoderService) }
+    let(:access_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'access_token'] }
+    let(:refresh_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'refresh_token'] }
+
+    before do
+      allow(OAuthTokenEncoderService).to receive(:new).and_return(oauth_token_encoder_service)
+      allow(oauth_token_encoder_service).to receive(:call).and_return(access_token_results, refresh_token_results)
+    end
+
+    include_context 'with an authenticated client', :post, :oauth_refresh_path
+
+    it_behaves_like 'an endpoint that requires client authentication'
+
+    context 'when the client provides an invalid JWT for refresh token' do
+      let(:refresh_token) { 'foobar' }
+
+      it 'responds with HTTP status bad request' do
+        call_endpoint
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'responds with error unsupported_grant_type as JSON' do
+        call_endpoint
+        expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+      end
+    end
+
+    context 'when the client provides an unsupported grant type' do
+      let(:grant_type) { 'foobar' }
+
+      it 'responds with HTTP status bad request' do
+        call_endpoint
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'responds with error unsupported_grant_type as JSON' do
+        call_endpoint
+        expect(response.parsed_body).to eq({ 'error' => 'unsupported_grant_type' })
+      end
+    end
+
+    context 'when oauth token creation raises the revoked session error' do
+      let(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'refreshed') }
+
+      it 'responds with HTTP status bad request' do
+        call_endpoint
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'responds with error server_error as JSON' do
+        call_endpoint
+        expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+      end
+
+      context 'with the same oauth session' do
+        # rubocop:disable RSpec/ExampleLength
+        it 'logs the refresh replay attack details' do
+          logger_spy = instance_spy(ActiveSupport::Logger)
+          allow(Rails).to receive(:logger).and_return(logger_spy)
+          call_endpoint
+          expect(logger_spy)
+            .to have_received(:warn)
+            .with(
+              I18n.t(
+                'oauth.revoked_session_error',
+                client_id: authorization_grant.client_id,
+                refreshed_session_id: oauth_session.id,
+                revoked_session_id: oauth_session.id,
+                user_id: user.id
+              )
+            )
+        end
+        # rubocop:enable RSpec/ExampleLength
+      end
+
+      context 'with a different active oauth session' do
+        let!(:active_oauth_session) { create(:oauth_session, authorization_grant:) }
+
+        # rubocop:disable RSpec/ExampleLength
+        it 'logs the refresh replay attack details' do
+          logger_spy = instance_spy(ActiveSupport::Logger)
+          allow(Rails).to receive(:logger).and_return(logger_spy)
+          call_endpoint
+          expect(logger_spy)
+            .to have_received(:warn)
+            .with(
+              I18n.t(
+                'oauth.revoked_session_error',
+                client_id: authorization_grant.client_id,
+                refreshed_session_id: oauth_session.id,
+                revoked_session_id: active_oauth_session.id,
+                user_id: user.id
+              )
+            )
+        end
+        # rubocop:enable RSpec/ExampleLength
+      end
+    end
+
+    context 'when all params are valid' do
+      it 'creates an OAuthSession record' do
+        expect { call_endpoint }.to change(OAuthSession, :count).by(1)
+      end
+
+      it 'responds with HTTP status ok' do
+        call_endpoint
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders the serialized token data' do
+        call_endpoint
+        expect(response.parsed_body).to include(
+          {
+            'access_token' => 'access_token',
+            'refresh_token' => 'refresh_token',
+            'token_type' => 'bearer',
+            'expires_in' => 5.minutes.from_now.to_i
+          }
+        )
+      end
+
+      context 'when oauth token creation raises the server error' do
+        let(:oauth_session_spy) { instance_spy(OAuthSession) }
+
+        before do
+          allow(OAuthSession).to receive(:find_by).and_return(oauth_session_spy)
+          allow(oauth_session_spy).to receive(:refresh).and_raise(OAuth::ServerError, 'foobar')
+        end
+
+        it 'responds with HTTP status internal_server_error' do
+          call_endpoint
+          expect(response).to have_http_status(:internal_server_error)
+        end
+
+        it 'responds with error server_error as JSON' do
+          call_endpoint
+          expect(response.parsed_body).to eq({ 'error' => 'server_error' })
+        end
+      end
+    end
+  end
 end

--- a/spec/routing/oauth/sessions_routing_spec.rb
+++ b/spec/routing/oauth/sessions_routing_spec.rb
@@ -4,6 +4,13 @@ require 'rails_helper'
 
 RSpec.describe OAuth::SessionsController do
   describe 'routing' do
+    it 'routes to #refresh' do
+      skip 'This route cannot be tested here due to an limitation of routings specs with respect to constraints'
+      expect(
+        post: '/oauth/token', grant_type: 'refresh_token'
+      ).to route_to(controller: 'oauth/sessions', action: 'refresh')
+    end
+
     it 'routes to #token' do
       expect(post: '/oauth/token').to route_to(controller: 'oauth/sessions', action: 'token')
     end


### PR DESCRIPTION
## Description

This PR adds functionality to refresh a user's OAuth session. The application will issue a new token pair if a valid refresh token is provided to the endpoint. It will detect if a refresh token has been replayed and revoke the active OAuth session.

## Testing

### Happy Path

* Follow the steps to get set-up with Postman [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#getting-started).
* Follow the steps to obtain an authorization code [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#authorization-code-grant).
* Follow the steps to redeem an authorization code [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#authorization-code-redemption).
  * Copy the access token from the previous step and paste into the `bearer_token` variable in Postman.
  * Copy the refresh token from the previous step and paste into the `refresh_token` variable in Postman.
* Follow the steps to retrieve user information from the API [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#current-user-data-retrieval).
* Send the `/oauth/token (refresh)` request.
* Verify a new access and refresh token pair are issued.
  * Copy the access token from the previous step and paste into the `bearer_token` variable in Postman.
  * Copy the refresh token from the previous step and paste into the `refresh_token` variable in Postman.
* Follow the steps to retrieve user information from the API [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#current-user-data-retrieval).
* Verify the API responds with a JSON object containing the user information.

### Refresh Token Replay Attack

* Follow the steps to get set-up with Postman [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#getting-started).
* Follow the steps to obtain an authorization code [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#authorization-code-grant).
* Follow the steps to redeem an authorization code [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#authorization-code-redemption).
  * Copy the access token from the previous step and paste into the `bearer_token` variable in Postman.
  * Copy the refresh token from the previous step and paste into the `refresh_token` variable in Postman.
* Follow the steps to retrieve user information from the API [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#current-user-data-retrieval).
* Send the `/oauth/token (refresh)` request.
* Verify a new access and refresh token pair are issued.
  * Copy the access token from the previous step and paste into the `bearer_token` variable in Postman.
  * Copy the refresh token from the previous step and paste into the `refresh_token` variable in Postman.
* Follow the steps to retrieve user information from the API [here](https://github.com/dickdavis/oauth-flow-demo/tree/main/docs/testing#current-user-data-retrieval).
* Verify the API responds with a JSON object containing the user information.
* Change the refresh_token variable back to the first refresh_token value.
* Send the `/oauth/token (refresh)` request.
* Verify the server responds with HTTP status code 400.
* Verify the server responds with response body:
```
{
    "error": "invalid_request"
}
```
* Verify the server logs contain the following entry:
```
Refresh token replay attack detected. Refreshed OAuthSession: [OAuth Session attempted to be refreshed by user], Revoked OAuthSession: [OAuth Session revoked by server], Client ID: [Client Name], User ID: [User ID]
```
