### PR TITLE
Refactor JTI claim validation

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -10,6 +10,7 @@ module API
 
     private
 
+    # rubocop:disable Metrics/AbcSize
     def user_from_token
       bearer_token_header = request.headers['AUTHORIZATION']
       raise OAuth::MissingAuthorizationHeaderError if bearer_token_header.blank?
@@ -18,10 +19,14 @@ module API
       access_token = AccessToken.new(JsonWebToken.decode(token))
       raise OAuth::UnauthorizedAccessTokenError unless access_token.valid?
 
+      oauth_session = OAuthSession.find_by(access_token_jti: access_token.jti)
+      raise OAuth::UnauthorizedAccessTokenError unless oauth_session.created_status?
+
       User.find(access_token.user_id)
     rescue JWT::DecodeError
       raise OAuth::InvalidAccessTokenError
     end
+    # rubocop:enable Metrics/AbcSize
 
     def missing_auth_header_response
       error_response(I18n.t('api.errors.missing_auth_header_response'))

--- a/app/models/concerns/claim_validatable.rb
+++ b/app/models/concerns/claim_validatable.rb
@@ -17,9 +17,6 @@ module ClaimValidatable
     attr_accessor :aud, :exp, :iat, :iss, :jti
 
     validates :jti, presence: true
-    validate do
-      errors.add(:jti, 'Invalid `jti` claim provided') unless oauth_session&.created_status?
-    end
 
     validates :aud, presence: true, format: { with: /\A#{OAUTH_CONFIG.audience_url}*/ }
 

--- a/spec/support/shared/claim_validatable.rb
+++ b/spec/support/shared/claim_validatable.rb
@@ -12,7 +12,6 @@ RSpec.shared_examples 'a model that validates token claims' do
     it { is_expected.not_to allow_value('http://foo.bar/').for(:iss) }
 
     it { is_expected.to validate_presence_of(:jti) }
-    it { is_expected.not_to allow_value('does-not-map-to-oauth-session').for(:jti) }
 
     it 'does not add any errors if all provided claims are valid' do
       expect(model).to be_valid


### PR DESCRIPTION
## Description
This PR removes JTI claim validation which checked the `OAuthSession` status. It then adds a check to the `API::BaseController#user_from_token` method to validate the `OAuthSession` status there instead.

## Testing
Regression test for api flow.

<details>
<summary>Screenshots</summary>

Add screenshots here.
</details>
