### PR TITLE
Extract OAuthSession creation into model concern

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -48,9 +48,9 @@ detectors:
     exclude:
       - ClientRedirectUrlService#call
       - API::BaseController#user_from_token
-      - AuthorizationGrant#create_oauth_session
       - AuthorizationGrantsController#create
       - OAuth::AuthorizationsController#authorize
+      - OAuthSessionCreatable#create_oauth_session
       - SessionsController#create
       - SessionsController#url_for_sign_in_redirect
       - StateTokenEncoderService#initialize

--- a/app/controllers/oauth/sessions_controller.rb
+++ b/app/controllers/oauth/sessions_controller.rb
@@ -29,7 +29,7 @@ module OAuth
         authorization_grant:, code_verifier: params[:code_verifier], grant_type: params[:grant_type]
       )
 
-      access_token, refresh_token, expiration = authorization_grant.create_oauth_session.deconstruct
+      access_token, refresh_token, expiration = authorization_grant.redeem.deconstruct
 
       render json: { access_token:, refresh_token:, token_type: 'bearer', expires_in: expiration }
     end

--- a/app/models/authorization_grant.rb
+++ b/app/models/authorization_grant.rb
@@ -3,6 +3,8 @@
 ##
 # Models an authorization grant.
 class AuthorizationGrant < ApplicationRecord
+  include OAuthSessionCreatable
+
   VALID_CODE_CHALLENGE_METHODS = %w[S256].freeze
 
   belongs_to :user
@@ -18,35 +20,17 @@ class AuthorizationGrant < ApplicationRecord
 
   validate :client_configuration
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-  def create_oauth_session
-    access_token_expiration = oauth_config.access_token_expiration.minutes.from_now
+  def active_oauth_session
+    oauth_sessions.created_status.order(created_at: :desc).first
+  end
 
-    access_token_jti, access_token = OAuthTokenEncoderService.call(
-      client_id:,
-      expiration: access_token_expiration,
-      optional_claims: { user_id: }
-    ).deconstruct
-
-    refresh_token_jti, refresh_token = OAuthTokenEncoderService.call(
-      client_id:,
-      expiration: oauth_config.refresh_token_expiration.minutes.from_now
-    ).deconstruct
-
-    oauth_session = oauth_sessions.new(access_token_jti:, refresh_token_jti:)
-    if oauth_session.save
+  def redeem
+    create_oauth_session(authorization_grant: self) do
       update(redeemed: true) unless redeemed?
-      Data
-        .define(:access_token, :refresh_token, :expiration)
-        .new(access_token, refresh_token, access_token_expiration.to_i)
-    else
-      errors = oauth_session.errors.full_messages.join(', ')
-      raise OAuth::ServerError, I18n.t('oauth.server_error.oauth_session_failure', errors:)
     end
-  rescue OAuth::InvalidTokenParamError => error
+  rescue OAuth::ServerError => error
     raise OAuth::ServerError, error.message
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   private
 

--- a/app/models/concerns/oauth_session_creatable.rb
+++ b/app/models/concerns/oauth_session_creatable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+##
+# Provides support for validating token claims
+module OAuthSessionCreatable
+  extend ActiveSupport::Concern
+
+  private
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def create_oauth_session(authorization_grant:)
+    access_token_expiration = oauth_config.access_token_expiration.minutes.from_now
+    client_id = authorization_grant.client_id
+
+    access_token_jti, access_token = OAuthTokenEncoderService.call(
+      client_id:,
+      expiration: access_token_expiration,
+      optional_claims: { user_id: }
+    ).deconstruct
+
+    refresh_token_jti, refresh_token = OAuthTokenEncoderService.call(
+      client_id:,
+      expiration: oauth_config.refresh_token_expiration.minutes.from_now
+    ).deconstruct
+
+    oauth_session = authorization_grant.oauth_sessions.new(access_token_jti:, refresh_token_jti:)
+    if oauth_session.save
+      yield
+      Data
+        .define(:access_token, :refresh_token, :expiration)
+        .new(access_token, refresh_token, access_token_expiration.to_i)
+    else
+      errors = oauth_session.errors.full_messages.join(', ')
+      raise OAuth::ServerError, I18n.t('oauth.server_error.oauth_session_failure', errors:)
+    end
+  rescue OAuth::InvalidTokenParamError => error
+    raise OAuth::ServerError, error.message
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  def oauth_config
+    @oauth_config ||= Rails.configuration.oauth
+  end
+end

--- a/spec/models/authorization_grant_spec.rb
+++ b/spec/models/authorization_grant_spec.rb
@@ -43,87 +43,50 @@ RSpec.describe AuthorizationGrant do
     it { is_expected.to have_many(:oauth_sessions) }
   end
 
-  describe '#create_oauth_session' do
-    subject(:method_call) { authorization_grant.create_oauth_session }
+  describe '#active_oauth_session' do
+    subject(:active_oauth_session) { authorization_grant.active_oauth_session }
 
     let(:authorization_grant) { create(:authorization_grant) }
 
-    context 'when the token request validator service does not raise an error' do
-      it 'calls the oauth token encoder service to create both the access and refresh tokens' do
-        allow(OAuthTokenEncoderService).to receive(:new).and_call_original
-        method_call
-        expect(OAuthTokenEncoderService).to have_received(:new).exactly(2).times
-      end
+    context 'when the authorization grant has an active oauth session' do
+      it 'returns the active oauth session for the authorization grant' do
+        _first_oauth_session = create(:oauth_session, authorization_grant:, status: 'refreshed')
+        _second_oauth_session = create(:oauth_session, authorization_grant:, status: 'refreshed')
+        third_oauth_session = create(:oauth_session, authorization_grant:)
 
-      it 'creates an OAuthSession record' do
-        expect { method_call }.to change(OAuthSession, :count).by(1)
-      end
-
-      it 'returns a valid access token' do
-        results = method_call
-        expect(results.access_token).to match(/\A[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\z/)
-      end
-
-      it 'saves the access_token_jti in the OAuthSession' do
-        results = method_call
-        token = JsonWebToken.decode(results.access_token)
-        expect(OAuthSession.last.access_token_jti).to eq(token[:jti])
-      end
-
-      it 'returns a valid refresh token' do
-        results = method_call
-        expect(results.refresh_token).to match(/\A[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\z/)
-      end
-
-      it 'saves the refresh_token_jti in the OAuthSession' do
-        results = method_call
-        token = JsonWebToken.decode(results.refresh_token)
-        expect(OAuthSession.last.refresh_token_jti).to eq(token[:jti])
-      end
-
-      it 'returns the access token expiration' do
-        results = method_call
-        token = JsonWebToken.decode(results.access_token)
-        expect(token[:exp]).to eq(results.expiration)
-      end
-
-      context 'when the authorization grant has not been redeemed' do
-        it 'updates the redeemed attribute' do
-          expect { method_call }.to change(authorization_grant, :redeemed).from(false).to(true)
-        end
-      end
-
-      context 'when the authorization grant has already been redeemed' do
-        let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
-
-        it 'does not update the redeemed attribute' do
-          expect { method_call }.not_to change(authorization_grant, :redeemed)
-        end
+        expect(active_oauth_session).to eq(third_oauth_session)
       end
     end
 
-    context 'when the oauth token encoder service raises the invalid request error' do
+    context 'when the authorization grant does not have an active oauth session' do
       before do
-        allow(OAuthTokenEncoderService).to receive(:new).and_raise(OAuth::InvalidTokenParamError, 'foobar')
+        create_list(:oauth_session, 3, authorization_grant:, status: 'refreshed')
       end
 
-      it 'raises an OAuth::ServerError' do
-        expect { method_call }.to raise_error(OAuth::ServerError, 'foobar')
+      it 'returns nil' do
+        expect(active_oauth_session).to be_nil
+      end
+    end
+  end
+
+  describe '#redeem' do
+    subject(:method_call) { authorization_grant.redeem }
+
+    let(:authorization_grant) { create(:authorization_grant) }
+
+    it_behaves_like 'a model that creates OAuth sessions'
+
+    context 'when the authorization grant has not been redeemed' do
+      it 'updates the redeemed attribute' do
+        expect { method_call }.to change(authorization_grant, :redeemed).from(false).to(true)
       end
     end
 
-    context 'when the oauth session fails to create' do
-      let(:oauth_session_double) { build(:oauth_session, authorization_grant:, access_token_jti: nil) }
+    context 'when the authorization grant has already been redeemed' do
+      let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
 
-      before do
-        allow(OAuthSession).to receive(:new).and_return(oauth_session_double)
-      end
-
-      it 'raises an OAuth::ServerError' do
-        expect { method_call }.to raise_error(
-          OAuth::ServerError,
-          "Failed to create OAuthSession. Errors: Access token jti can't be blank, Access token jti is invalid"
-        )
+      it 'does not update the redeemed attribute' do
+        expect { method_call }.not_to change(authorization_grant, :redeemed)
       end
     end
   end

--- a/spec/requests/oauth/sessions_controller_spec.rb
+++ b/spec/requests/oauth/sessions_controller_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe OAuth::SessionsController do # rubocop:disable RSpec/FilePath
 
         before do
           allow(AuthorizationGrant).to receive(:find_by).and_return(authorization_grant_spy)
-          allow(authorization_grant_spy).to receive(:create_oauth_session).and_raise(OAuth::ServerError, 'foobar')
+          allow(authorization_grant_spy).to receive(:redeem).and_raise(OAuth::ServerError, 'foobar')
         end
 
         it 'responds with HTTP status internal_server_error' do

--- a/spec/support/shared/oauth_session_creatable.rb
+++ b/spec/support/shared/oauth_session_creatable.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a model that creates OAuth sessions' do
+  context 'when the token request validator service does not raise an error' do
+    it 'calls the oauth token encoder service to create both the access and refresh tokens' do
+      allow(OAuthTokenEncoderService).to receive(:new).and_call_original
+      method_call
+      expect(OAuthTokenEncoderService).to have_received(:new).exactly(2).times
+    end
+
+    it 'creates an OAuthSession record' do
+      expect { method_call }.to change(OAuthSession, :count).by(1)
+    end
+
+    it 'returns a valid access token' do
+      results = method_call
+      expect(results.access_token).to match(/\A[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\z/)
+    end
+
+    it 'saves the access_token_jti in the OAuthSession' do
+      results = method_call
+      token = JsonWebToken.decode(results.access_token)
+      expect(authorization_grant.active_oauth_session.access_token_jti).to eq(token[:jti])
+    end
+
+    it 'returns a valid refresh token' do
+      results = method_call
+      expect(results.refresh_token).to match(/\A[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\z/)
+    end
+
+    it 'saves the refresh_token_jti in the OAuthSession' do
+      results = method_call
+      token = JsonWebToken.decode(results.refresh_token)
+      expect(authorization_grant.active_oauth_session.refresh_token_jti).to eq(token[:jti])
+    end
+
+    it 'returns the access token expiration' do
+      results = method_call
+      token = JsonWebToken.decode(results.access_token)
+      expect(token[:exp]).to eq(results.expiration)
+    end
+  end
+
+  context 'when the oauth token encoder service raises the invalid request error' do
+    before do
+      allow(OAuthTokenEncoderService).to receive(:new).and_raise(OAuth::InvalidTokenParamError, 'foobar')
+    end
+
+    it 'raises an OAuth::ServerError' do
+      expect { method_call }.to raise_error(OAuth::ServerError, 'foobar')
+    end
+  end
+
+  context 'when the oauth session fails to create' do
+    let(:oauth_session_double) { build(:oauth_session, authorization_grant:, access_token_jti: nil) }
+
+    before do
+      allow(OAuthSession).to receive(:new).and_return(oauth_session_double)
+    end
+
+    it 'raises an OAuth::ServerError' do
+      expect { method_call }.to raise_error(
+        OAuth::ServerError,
+        "Failed to create OAuthSession. Errors: Access token jti can't be blank, Access token jti is invalid"
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR extracts `OAuthSession` creation into a model concern. This will allow it to be reused when refreshing a session.

## Testing
Regression test for access token generation.

<details>
<summary>Screenshots</summary>

Add screenshots here.
</details>
