### PR TITLE
Refactor token routing constraints

### DIFF
--- a/app/controllers/oauth/sessions_controller.rb
+++ b/app/controllers/oauth/sessions_controller.rb
@@ -8,12 +8,6 @@ module OAuth
 
     skip_before_action :verify_authenticity_token
 
-    before_action :validate_grant_type
-
-    rescue_from OAuth::UnsupportedGrantTypeError do
-      render_token_request_error(error: 'unsupported_grant_type')
-    end
-
     rescue_from OAuth::InvalidGrantError do
       render_token_request_error(error: 'invalid_grant')
     end
@@ -50,11 +44,11 @@ module OAuth
       render_token_request_error(error: 'invalid_request')
     end
 
-    private
-
-    def validate_grant_type
-      raise OAuth::UnsupportedGrantTypeError unless PERMITTED_GRANT_TYPES.include?(params[:grant_type])
+    def unsupported_grant_type
+      render_token_request_error(error: 'unsupported_grant_type')
     end
+
+    private
 
     def render_token_request_error(error:, status: :bad_request)
       render json: { error: }, status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ##
-# Provides a route constraint for when the grant type is 'refresh_token'
+# Provides a route constraint for matching `grant_type`
 GrantTypeConstraint = Struct.new(:grant_type) do
   def matches?(request)
     request.request_parameters['grant_type'] == grant_type
@@ -17,8 +17,16 @@ Rails.application.routes.draw do
 
   namespace :oauth do
     get 'authorize', to: 'authorizations#authorize'
-    post 'token', to: 'sessions#refresh', constraints: GrantTypeConstraint.new('refresh_token'), as: :refresh
-    post 'token', to: 'sessions#token'
+
+    constraints(GrantTypeConstraint.new('refresh_token')) do
+      post 'token', to: 'sessions#refresh', as: :refresh_session
+    end
+
+    constraints(GrantTypeConstraint.new('authorization_code')) do
+      post 'token', to: 'sessions#token', as: :create_session
+    end
+
+    post 'token', to: 'sessions#unsupported_grant_type', as: :unsupported_grant_type
   end
 
   resources :authorization_grants, path: 'authorization-grants', only: %i[new create]

--- a/spec/routing/oauth/sessions_routing_spec.rb
+++ b/spec/routing/oauth/sessions_routing_spec.rb
@@ -3,16 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe OAuth::SessionsController do
+  # rubocop:disable RSpec/EmptyExampleGroup
   describe 'routing' do
-    it 'routes to #refresh' do
-      skip 'This route cannot be tested here due to an limitation of routings specs with respect to constraints'
-      expect(
-        post: '/oauth/token', grant_type: 'refresh_token'
-      ).to route_to(controller: 'oauth/sessions', action: 'refresh')
-    end
-
-    it 'routes to #token' do
-      expect(post: '/oauth/token').to route_to(controller: 'oauth/sessions', action: 'token')
-    end
+    # Specs ommitted due to routing spec limitations with respect to constraints
   end
+  # rubocop:enable RSpec/EmptyExampleGroup
 end


### PR DESCRIPTION
## Description

This PR refactors how the `token` endpoint is constrained.

<details>
<summary>Screenshots</summary>

Add screenshots here.
</details>

## Testing

* Perform regression for refresh token session creation.
* Perform regression for authorization code session creation.
* Send a request without grant type; verify unsupported_grant_type error is received.
