### PR TITLE
Improve spec performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-factory_bot
+  - 'test_prof/rubocop'
+
+inherit_gem:
+  test-prof: config/rubocop-rspec.yml
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'
+  gem 'vernier', require: false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,5 @@ end
 
 group :test do
   gem 'shoulda-matchers'
+  gem 'test-prof'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,7 @@ GEM
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.30-x86_64-linux)
       railties (>= 6.0.0)
+    test-prof (1.3.3)
     thor (1.2.2)
     tilt (2.2.0)
     timeout (0.4.0)
@@ -331,6 +332,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   tailwindcss-rails
+  test-prof
   turbo-rails
   tzinfo-data
   web-console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    vernier (1.0.1)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -335,6 +336,7 @@ DEPENDENCIES
   test-prof
   turbo-rails
   tzinfo-data
+  vernier
   web-console
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -30,3 +30,65 @@ bin/dev
 Note: It's important to use `bin/dev` to run the server as it uses Foreman to manage both the Rails server and the TailwindCSS JIT compiler.
 
 If you are experiencing any TailwindCSS-related errors, you should ensure you have a recent version of Node.js installed locally. It may also be necessary to change some bundler platform configuration to build the gems native for your platform. See [here](https://github.com/rails/tailwindcss-rails#check-bundle_force_ruby_platform)
+
+## Test Suite
+
+Run the test suite by executing `bundle exec rspec`.
+
+### Performance
+
+The commands listed below will help assess the performance of the test suite and identity possible areas of improvement. Refer to the `test-prof` [documentation](https://test-prof.evilmartians.io) for more information.
+
+Measure execution time by spec type:
+
+```
+TAG_PROF=type bundle exec rspec
+```
+
+Generate a chart showing execution time by spec type and event:
+
+```
+TAG_PROF=type TAG_PROF_FORMAT=html TAG_PROF_EVENT=sql.active_record,factory.create bundle exec rspec
+```
+
+Measure execution time for database interactions:
+
+```
+EVENT_PROF='sql.active_record' bundle exec rspec
+```
+
+Measure execution time for factories:
+
+```
+EVENT_PROF='factory.create' bundle exec rspec
+```
+
+Check for suboptimal usage of factories:
+
+```
+FDOC=1 bundle exec rspec
+```
+
+Identify all usages of factories:
+
+```
+FPROF=1 bundle exec rspec
+```
+
+Generate a flamegraph of factory usage:
+
+```
+FPROF=flamegraph bundle exec rspec
+```
+
+Check for possible usages of factory defaults:
+
+```
+FACTORY_DEFAULT_PROF=1 bundle exec rspec --tag slow:factory
+```
+
+Measure time spent in spec set-up:
+
+```
+RD_PROF=1 bundle exec rspec
+```

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe AccessToken do
   subject(:model) { build(:access_token, oauth_session:) }
 
+  let_it_be(:user) { create(:user) }
+  let_it_be(:authorization_grant) { create(:authorization_grant, user:) }
   let(:oauth_session) { create(:oauth_session, authorization_grant:) }
-  let(:authorization_grant) { create(:authorization_grant, user:) }
-  let(:user) { create(:user) }
 
   it_behaves_like 'a model that validates token claims'
 

--- a/spec/models/authorization_grant_spec.rb
+++ b/spec/models/authorization_grant_spec.rb
@@ -6,45 +6,58 @@ RSpec.describe AuthorizationGrant do
   subject(:model) { build(:authorization_grant) }
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:code_challenge) }
-    it { is_expected.to validate_presence_of(:code_challenge_method) }
-    it { is_expected.to validate_presence_of(:client_id) }
-    it { is_expected.to validate_presence_of(:client_redirection_uri) }
-
-    it 'adds an error if client_id is not configured' do
-      model.client_id = 'invalidclient'
-      model.save
-      expect(model.errors).to include(:client_id)
+    describe 'code_challenge' do
+      it { is_expected.to validate_presence_of(:code_challenge) }
     end
 
-    it 'does not add an error if client_id is configured' do
-      model.client_id = 'democlient'
-      model.save
-      expect(model.errors).not_to include(:client_id)
+    describe 'code_challenge_method' do
+      it { is_expected.to validate_presence_of(:code_challenge_method) }
     end
 
-    it 'adds an error if client_redirection_uri does not match client configuration' do
-      model.client_redirection_uri = 'http://not-configured.for/client'
-      model.save
-      expect(model.errors).to include(:client_redirection_uri)
+    describe 'client_id' do
+      it { is_expected.to validate_presence_of(:client_id) }
+
+      it 'adds an error if client_id is not configured' do
+        model.client_id = 'invalidclient'
+        model.valid?
+        expect(model.errors).to include(:client_id)
+      end
+
+      it 'does not add an error if client_id is configured' do
+        model.client_id = 'democlient'
+        model.valid?
+        expect(model.errors).not_to include(:client_id)
+      end
     end
 
-    it 'does not add an error if client_redirect_uri matches client configuration' do
-      model.client_id = 'http://localhost:3000/'
-      model.save
-      expect(model.errors).not_to include(:client_redirection_uri)
+    describe 'client_redirection_uri' do
+      it { is_expected.to validate_presence_of(:client_redirection_uri) }
+
+      it 'adds an error if client_redirection_uri does not match client configuration' do
+        model.client_redirection_uri = 'http://not-configured.for/client'
+        model.valid?
+        expect(model.errors).to include(:client_redirection_uri)
+      end
+
+      it 'does not add an error if client_redirect_uri matches client configuration' do
+        model.client_id = 'http://localhost:3000/'
+        model.valid?
+        expect(model.errors).not_to include(:client_redirection_uri)
+      end
     end
   end
 
   describe 'associations' do
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to have_many(:oauth_sessions) }
+    specify(:aggregate_failures) do
+      expect(model).to belong_to(:user)
+      expect(model).to have_many(:oauth_sessions)
+    end
   end
 
   describe '#active_oauth_session' do
-    subject(:active_oauth_session) { authorization_grant.active_oauth_session }
+    subject(:method_call) { authorization_grant.active_oauth_session }
 
-    let(:authorization_grant) { create(:authorization_grant) }
+    let_it_be(:authorization_grant) { create(:authorization_grant) }
 
     context 'when the authorization grant has an active oauth session' do
       it 'returns the active oauth session for the authorization grant' do
@@ -52,7 +65,7 @@ RSpec.describe AuthorizationGrant do
         _second_oauth_session = create(:oauth_session, authorization_grant:, status: 'refreshed')
         third_oauth_session = create(:oauth_session, authorization_grant:)
 
-        expect(active_oauth_session).to eq(third_oauth_session)
+        expect(method_call).to eq(third_oauth_session)
       end
     end
 
@@ -62,7 +75,7 @@ RSpec.describe AuthorizationGrant do
       end
 
       it 'returns nil' do
-        expect(active_oauth_session).to be_nil
+        expect(method_call).to be_nil
       end
     end
   end
@@ -70,14 +83,23 @@ RSpec.describe AuthorizationGrant do
   describe '#redeem' do
     subject(:method_call) { authorization_grant.redeem(code_verifier:) }
 
-    let(:authorization_grant) { create(:authorization_grant) }
     let(:code_verifier) { 'code_verifier' }
 
-    it_behaves_like 'a model that creates OAuth sessions'
-
     context 'when the authorization grant has not been redeemed' do
+      let_it_be(:authorization_grant) { create(:authorization_grant) }
+
+      it_behaves_like 'a model that creates OAuth sessions'
+
       it 'updates the redeemed attribute' do
         expect { method_call }.to change(authorization_grant, :redeemed).from(false).to(true)
+      end
+
+      context 'when the code verifier does not match the code challenge for the authorization grant' do
+        let(:code_verifier) { 'foobar' }
+
+        it 'raises an OAuth::InvalidCodeVerifierError' do
+          expect { method_call }.to raise_error(OAuth::InvalidCodeVerifierError)
+        end
       end
     end
 
@@ -86,14 +108,6 @@ RSpec.describe AuthorizationGrant do
 
       it 'does not update the redeemed attribute' do
         expect { method_call }.not_to change(authorization_grant, :redeemed)
-      end
-    end
-
-    context 'when the code verifier does not match the code challenge for the authorization grant' do
-      let(:code_verifier) { 'foobar' }
-
-      it 'raises an OAuth::InvalidCodeVerifierError' do
-        expect { method_call }.to raise_error(OAuth::InvalidCodeVerifierError)
       end
     end
   end

--- a/spec/models/oauth_session_spec.rb
+++ b/spec/models/oauth_session_spec.rb
@@ -6,23 +6,43 @@ RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
   subject(:model) { build(:oauth_session) }
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:access_token_jti) }
-    it { is_expected.to validate_uniqueness_of(:access_token_jti) }
-    it { is_expected.to allow_value(SecureRandom.uuid).for(:access_token_jti) }
-    it { is_expected.not_to allow_value('foobar').for(:access_token_jti) }
+    describe 'access_token_jti' do
+      it { is_expected.to validate_presence_of(:access_token_jti) }
 
-    it { is_expected.to validate_presence_of(:refresh_token_jti) }
-    it { is_expected.to validate_uniqueness_of(:refresh_token_jti) }
-    it { is_expected.to allow_value(SecureRandom.uuid).for(:refresh_token_jti) }
-    it { is_expected.not_to allow_value('foobar').for(:refresh_token_jti) }
+      it 'validates values for access_token_jti' do
+        aggregate_failures do
+          expect(model).to validate_uniqueness_of(:access_token_jti)
+          expect(model).to allow_value(SecureRandom.uuid).for(:access_token_jti)
+          expect(model).not_to allow_value('foobar').for(:access_token_jti)
+        end
+      end
+    end
 
-    it { is_expected.to allow_value('created').for(:status) }
-    it { is_expected.to allow_value('expired').for(:status) }
-    it { is_expected.to allow_value('refreshed').for(:status) }
-    it { is_expected.to allow_value('revoked').for(:status) }
+    describe 'refresh_token_jti' do
+      it { is_expected.to validate_presence_of(:refresh_token_jti) }
 
-    it 'raises an ArgumentError when an invalid status is provided' do
-      expect { model.status = 'foobar' }.to raise_error(ArgumentError)
+      it 'validates values for refresh_token_jti' do
+        aggregate_failures do
+          expect(model).to validate_uniqueness_of(:refresh_token_jti)
+          expect(model).to allow_value(SecureRandom.uuid).for(:refresh_token_jti)
+          expect(model).not_to allow_value('foobar').for(:refresh_token_jti)
+        end
+      end
+    end
+
+    describe 'status' do
+      it 'validates values for status' do
+        aggregate_failures do
+          expect(model).to allow_value('created').for(:status)
+          expect(model).to allow_value('expired').for(:status)
+          expect(model).to allow_value('refreshed').for(:status)
+          expect(model).to allow_value('revoked').for(:status)
+        end
+      end
+
+      it 'raises an ArgumentError when an invalid status is provided' do
+        expect { model.status = 'foobar' }.to raise_error(ArgumentError)
+      end
     end
   end
 
@@ -33,241 +53,129 @@ RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
   describe '#refresh' do
     subject(:method_call) { oauth_session.refresh(token: refresh_token) }
 
+    let_it_be(:authorization_grant) { create(:authorization_grant, redeemed: true) }
     let!(:oauth_session) { create(:oauth_session, authorization_grant:) }
-    let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
     let(:refresh_token) { build(:refresh_token, oauth_session:) }
 
     it_behaves_like 'a model that creates OAuth sessions'
 
-    context 'when the oauth session is in created status' do
-      it 'updates the status attribute to refreshed' do
-        expect { method_call }.to change(oauth_session, :status).from('created').to('refreshed')
-      end
-
-      it 'creates a new oauth session' do
-        expect { method_call }.to change(described_class, :count).by(1)
+    context 'when the OAuth session is in created status' do
+      it 'refreshes the OAuth session' do
+        aggregate_failures do
+          expect { method_call }.to change(oauth_session, :status).from('created').to('refreshed')
+          expect(described_class.count).to eq(2)
+        end
       end
     end
 
-    context 'when the provided token contains a JTI that does not match the refresh token JTI of the oauth session' do
+    context 'when the provided token contains a JTI that does not match the refresh token JTI of the OAuth session' do
       let(:refresh_token) { build(:refresh_token, oauth_session:, jti: 'foobar') }
 
-      it 'raises an OAuth::ServerError' do
-        expect { method_call }.to raise_error(OAuth::ServerError, I18n.t('oauth.mismatched_refresh_token_error'))
-      end
-
-      it 'does not create a new oauth session' do
-        begin
-          method_call
-        rescue OAuth::ServerError
-          nil
+      it 'does not refresh the OAuth session and raises an OAuth::ServerError' do
+        aggregate_failures do
+          expect { method_call }.to raise_error(OAuth::ServerError, I18n.t('oauth.mismatched_refresh_token_error'))
+          expect(described_class.count).to eq(1)
         end
-        expect(described_class.count).to eq(1)
       end
     end
 
     context 'when the provided token has invalid claims' do
       let(:refresh_token) { build(:refresh_token, oauth_session:, exp: 14.days.ago.to_i) }
 
-      it 'raises an OAuth::InvalidGrantError' do
-        expect { method_call }.to raise_error(OAuth::InvalidGrantError)
-      end
-
-      it 'does not create a new oauth session' do
-        begin
-          method_call
-        rescue OAuth::InvalidGrantError
-          nil
-        end
-        expect(described_class.count).to eq(1)
-      end
-    end
-
-    context 'when the oauth session has already been refreshed' do
-      let!(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'refreshed') }
-
-      context 'with an active oauth session existing for authorization grant' do
-        it 'revokes the active oauth session' do
-          active_oauth_session = create(:oauth_session, authorization_grant:)
-          expect do
-            method_call
-          rescue OAuth::RevokedSessionError
-            active_oauth_session.reload
-          end.to change(active_oauth_session, :status).from('created').to('revoked')
-        end
-
-        it 'raises an OAuth::RevokedSessionError' do
-          create(:oauth_session, authorization_grant:)
-          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
-        end
-
-        it 'does not create a new oauth session' do
-          create(:oauth_session, authorization_grant:)
-          begin
-            method_call
-          rescue OAuth::RevokedSessionError
-            nil
-          end
-          expect(described_class.count).to eq(2)
-        end
-      end
-
-      context 'without an active oauth session existing for authorization grant' do
-        it 'changes its own status to revoked' do
-          expect do
-            method_call
-          rescue OAuth::RevokedSessionError
-            nil
-          end.to change(oauth_session, :status).from('refreshed').to('revoked')
-        end
-
-        it 'raises an OAuth::RevokedSessionError' do
-          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
-        end
-
-        it 'does not create a new oauth session' do
-          begin
-            method_call
-          rescue OAuth::RevokedSessionError
-            nil
-          end
+      it 'does not refresh the session and raises an OAuth::InvalidGrantError' do
+        aggregate_failures do
+          expect { method_call }.to raise_error(OAuth::InvalidGrantError)
           expect(described_class.count).to eq(1)
         end
       end
     end
 
-    context 'when the oauth session has already been revoked' do
-      let!(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'revoked') }
+    context 'when the OAuth session has already been refreshed' do
+      let_it_be(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'refreshed') }
 
-      context 'with an active oauth session existing for authorization grant' do
-        it 'revokes the active oauth session' do
+      context 'with an active OAuth session existing for authorization grant' do
+        it 'revokes the OAuth session and raises an OAuth::RevokedSessionError' do
           active_oauth_session = create(:oauth_session, authorization_grant:)
-          expect do
-            method_call
-          rescue OAuth::RevokedSessionError
-            active_oauth_session.reload
-          end.to change(active_oauth_session, :status).from('created').to('revoked')
-        end
-
-        it 'raises an OAuth::RevokedSessionError' do
-          create(:oauth_session, authorization_grant:)
-          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
-        end
-
-        it 'does not create a new oauth session' do
-          create(:oauth_session, authorization_grant:)
-          begin
-            method_call
-          rescue OAuth::RevokedSessionError
-            nil
+          aggregate_failures do
+            expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+            expect(active_oauth_session.reload).to be_revoked_status
+            expect(described_class.count).to eq(2)
           end
-          expect(described_class.count).to eq(2)
         end
       end
 
-      context 'without an active oauth session existing for authorization grant' do
-        it 'keeps its own status as revoked' do
-          begin
-            method_call
-          rescue OAuth::RevokedSessionError
-            nil
+      context 'without an active OAuth session existing for authorization grant' do
+        it 'does not refresh the OAuth session and raises an OAuth::RevokedSessionError' do
+          aggregate_failures do
+            expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+            expect(oauth_session.reload).to be_revoked_status
+            expect(described_class.count).to eq(1)
           end
-          expect(oauth_session.reload).to be_revoked_status
         end
+      end
+    end
 
-        it 'raises an OAuth::RevokedSessionError' do
-          expect { method_call }.to raise_error(OAuth::RevokedSessionError)
-        end
+    context 'when the OAuth session has already been revoked' do
+      let_it_be(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'revoked') }
 
-        it 'does not create a new oauth session' do
-          begin
-            method_call
-          rescue OAuth::RevokedSessionError
-            nil
+      context 'with an active OAuth session existing for authorization grant' do
+        it 'revokes the active OAuth session and raises an OAuth::RevokedSessionError' do
+          active_oauth_session = create(:oauth_session, authorization_grant:)
+          aggregate_failures do
+            expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+            expect(active_oauth_session.reload).to be_revoked_status
+            expect(oauth_session.reload).to be_revoked_status
+            expect(described_class.count).to eq(2)
           end
-          expect(described_class.count).to eq(1)
+        end
+      end
+
+      context 'without an active OAuth session existing for authorization grant' do
+        it 'does not refresh the OAuth session and raises an OAuth::RevokedSessionError' do
+          aggregate_failures do
+            expect { method_call }.to raise_error(OAuth::RevokedSessionError)
+            expect(oauth_session.reload).to be_revoked_status
+            expect(described_class.count).to eq(1)
+          end
         end
       end
     end
   end
 
   describe 'revocation' do
-    RSpec.shared_examples 'revokes self' do
-      let(:oauth_session) { create(:oauth_session, authorization_grant:) }
-      let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
+    RSpec.shared_examples 'a revocable OAuth session' do
+      let_it_be(:authorization_grant) { create(:authorization_grant, redeemed: true) }
 
-      before do
-        # Set-up unrelated oauth sessions
-        create(:oauth_session, authorization_grant: create(:authorization_grant, redeemed: true))
-        create(:oauth_session, authorization_grant: create(:authorization_grant, redeemed: true))
-        create(:oauth_session, authorization_grant: create(:authorization_grant, redeemed: true))
-      end
+      context 'when the OAuth session is the active OAuth session' do
+        let(:oauth_session) { create(:oauth_session, authorization_grant:) }
 
-      it 'revokes the oauth session' do
-        expect do
-          method_call
-          oauth_session.reload
-        end.to change(oauth_session, :status).from('created').to('revoked')
-      end
-
-      it 'does not revoke other oauth sessions' do
-        method_call
-        expect(described_class.where(status: 'revoked').count).to eq(1)
-      end
-    end
-
-    RSpec.shared_examples 'revokes active oauth session' do
-      let(:oauth_session) { create(:oauth_session, authorization_grant:) }
-      let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
-
-      before do
-        # Set-up unrelated oauth sessions
-        create(:oauth_session, authorization_grant: create(:authorization_grant, redeemed: true))
-        create(:oauth_session, authorization_grant: create(:authorization_grant, redeemed: true))
-        create(:oauth_session, authorization_grant: create(:authorization_grant, redeemed: true))
-
-        # Set-up a chain of oauth sessions related to an authorization grant
-        create(:oauth_session, authorization_grant:, status: 'refreshed')
-        create(:oauth_session, authorization_grant:, status: 'refreshed')
-      end
-
-      context 'when the oauth session is the active oauth session' do
-        it 'revokes the oauth session' do
-          expect do
-            method_call
-            oauth_session.reload
-          end.to change(oauth_session, :status).from('created').to('revoked')
-        end
-
-        it 'does not revoke other oauth sessions' do
-          method_call
-          expect(described_class.where(status: 'revoked').count).to eq(1)
+        it 'only revokes the active OAuth session' do
+          other_oauth_session = create(:oauth_session, authorization_grant:, status: 'refreshed')
+          aggregate_failures do
+            expect do
+              method_call
+              oauth_session.reload
+            end.to change(oauth_session, :status).from('created').to('revoked')
+            expect(other_oauth_session.reload.status).to eq('refreshed')
+            expect(described_class.where(status: 'revoked').count).to eq(1)
+          end
         end
       end
 
-      context 'when the oauth session is not the active oauth session' do
+      context 'when the OAuth session is not the active OAuth session' do
         let(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'refreshed') }
 
-        it 'revokes the oauth session' do
-          create(:oauth_session, authorization_grant:)
-          expect do
-            method_call
-            oauth_session.reload
-          end.to change(oauth_session, :status).from('refreshed').to('revoked')
-        end
-
-        it 'revokes the active oauth session for the authorization grant' do
+        it 'only revokes all related OAuth sessions for the authorization grant' do
           active_oauth_session = create(:oauth_session, authorization_grant:)
-          expect do
-            method_call
-            active_oauth_session.reload
-          end.to change(active_oauth_session, :status).from('created').to('revoked')
-        end
-
-        it 'does not revoke unrelated oauth sessions' do
-          create(:oauth_session, authorization_grant:)
-          method_call
-          expect(described_class.where(status: 'revoked').count).to eq(2)
+          alt_oauth_session = create(:oauth_session, authorization_grant: create(:authorization_grant, redeemed: true))
+          aggregate_failures do
+            expect do
+              method_call
+              active_oauth_session.reload
+            end.to change(active_oauth_session, :status).from('created').to('revoked')
+            expect(alt_oauth_session.reload.status).to eq('created')
+            expect(described_class.where(status: 'revoked').count).to eq(2)
+          end
         end
       end
     end
@@ -275,8 +183,7 @@ RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
     describe '#revoke_self_and_active_session' do
       let(:method_call) { oauth_session.revoke_self_and_active_session }
 
-      it_behaves_like 'revokes self'
-      it_behaves_like 'revokes active oauth session'
+      it_behaves_like 'a revocable OAuth session'
     end
 
     describe '.revoke_for_token' do
@@ -287,15 +194,13 @@ RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
       context 'when provided an access token JTI' do
         let(:token) { build(:access_token, oauth_session:) }
 
-        it_behaves_like 'revokes self'
-        it_behaves_like 'revokes active oauth session'
+        it_behaves_like 'a revocable OAuth session'
       end
 
       context 'when provided a refresh token JTI' do
         let(:token) { build(:refresh_token, oauth_session:) }
 
-        it_behaves_like 'revokes self'
-        it_behaves_like 'revokes active oauth session'
+        it_behaves_like 'a revocable OAuth session'
       end
     end
 
@@ -303,11 +208,9 @@ RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
       subject(:method_call) { described_class.revoke_for_access_token(access_token_jti:) }
 
       let(:access_token_jti) { token.jti }
-
       let(:token) { build(:access_token, oauth_session:) }
 
-      it_behaves_like 'revokes self'
-      it_behaves_like 'revokes active oauth session'
+      it_behaves_like 'a revocable OAuth session'
     end
 
     describe '.revoke_for_refresh_token' do
@@ -316,8 +219,7 @@ RSpec.describe OAuthSession do # rubocop:disable RSpec/FilePath
       let(:refresh_token_jti) { token.jti }
       let(:token) { build(:refresh_token, oauth_session:) }
 
-      it_behaves_like 'revokes self'
-      it_behaves_like 'revokes active oauth session'
+      it_behaves_like 'a revocable OAuth session'
     end
   end
 end

--- a/spec/models/refresh_token_spec.rb
+++ b/spec/models/refresh_token_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe RefreshToken do
   subject(:model) { build(:refresh_token, oauth_session:) }
 
+  let_it_be(:user) { create(:user) }
+  let_it_be(:authorization_grant) { create(:authorization_grant, user:) }
   let(:oauth_session) { create(:oauth_session, authorization_grant:) }
-  let(:authorization_grant) { create(:authorization_grant, user:) }
-  let(:user) { create(:user) }
 
   it_behaves_like 'a model that validates token claims'
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,17 +6,34 @@ RSpec.describe User do
   subject(:model) { build(:user) }
 
   describe 'validations' do
-    it { is_expected.to have_secure_password }
-    it { is_expected.to validate_presence_of(:first_name) }
-    it { is_expected.to validate_length_of(:first_name).is_at_most(255) }
-    it { is_expected.to validate_presence_of(:last_name) }
-    it { is_expected.to validate_length_of(:last_name).is_at_most(255) }
-    it { is_expected.to validate_presence_of(:email) }
-    it { is_expected.to validate_length_of(:email).is_at_most(255) }
-    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
-    it { is_expected.to allow_value('test@test.com').for(:email) }
-    it { is_expected.not_to allow_value('test@test').for(:email) }
-    it { is_expected.not_to allow_value('testtest.com').for(:email) }
+    specify(:aggregate_failures) do
+      expect(model).to have_secure_password
+    end
+
+    describe 'email' do
+      specify(:aggregate_failures) do
+        expect(model).to validate_presence_of(:email)
+        expect(model).to validate_uniqueness_of(:email).case_insensitive
+        expect(model).to allow_value('test@test.com').for(:email)
+        expect(model).not_to allow_value('test@test').for(:email)
+        expect(model).not_to allow_value('testtest.com').for(:email)
+        expect(model).to validate_length_of(:email).is_at_most(255)
+      end
+    end
+
+    describe 'first_name' do
+      specify(:aggregate_failures) do
+        expect(model).to validate_presence_of(:first_name)
+        expect(model).to validate_length_of(:first_name).is_at_most(255)
+      end
+    end
+
+    describe 'last_name' do
+      specify(:aggregate_failures) do
+        expect(model).to validate_presence_of(:last_name)
+        expect(model).to validate_length_of(:last_name).is_at_most(255)
+      end
+    end
   end
 
   describe 'associations' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 
+require 'test_prof/recipes/rspec/before_all'
+require 'test_prof/recipes/rspec/let_it_be'
+
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }
 
 begin

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -4,23 +4,19 @@ require 'rails_helper'
 
 RSpec.describe API::V1::UsersController do
   describe 'GET /current' do
-    let(:params) { {} }
-    let(:headers) { {} }
-    let(:user) { create(:user) }
+    let_it_be(:user) { create(:user) }
 
     include_context 'with a valid access token', :get, :api_v1_current_user_path
 
     it_behaves_like 'an endpoint that requires token authentication'
 
-    it 'renders a successful response' do
-      call_endpoint
-      expect(response).to be_successful
-    end
-
-    it 'renders the serialized data' do
+    it 'renders a successful response and the serialized data' do
       allow(UserBlueprint).to receive(:render)
       call_endpoint
-      expect(UserBlueprint).to have_received(:render).with(user)
+      aggregate_failures do
+        expect(response).to be_successful
+        expect(UserBlueprint).to have_received(:render).with(user)
+      end
     end
   end
 end

--- a/spec/requests/oauth/authorization_grants_controller_spec.rb
+++ b/spec/requests/oauth/authorization_grants_controller_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe OAuth::AuthorizationGrantsController do
   describe 'GET /new' do
     subject(:call_endpoint) { get new_oauth_authorization_grant_path, params: { state: } }
 
-    let(:user) { create(:user) }
-    let(:state) { JsonWebToken.encode({ client_id: 'democlient' }) }
+    let_it_be(:user) { create(:user) }
+    let_it_be(:state) { JsonWebToken.encode({ client_id: 'democlient' }) }
 
-    before do
+    before_all do
       sign_in(user)
     end
 
@@ -24,34 +24,35 @@ RSpec.describe OAuth::AuthorizationGrantsController do
   describe 'POST /create' do
     subject(:call_endpoint) { post oauth_authorization_grants_path, params: { state:, approve: } }
 
-    let(:user) { create(:user) }
+    let_it_be(:user) { create(:user) }
     let(:approve) { 'true' }
-    let(:state) { JsonWebToken.encode(payload) }
-    let(:payload) do
-      {
-        client_id: 'democlient',
-        client_state: 'foo',
-        code_challenge: 'bar',
-        code_challenge_method: 'S256'
-      }
+    let_it_be(:state) do
+      JsonWebToken.encode(
+        {
+          client_id: 'democlient',
+          client_state: 'foo',
+          code_challenge: 'bar',
+          code_challenge_method: 'S256'
+        }
+      )
     end
 
-    before do
+    before_all do
       sign_in(user)
     end
 
     it_behaves_like 'an endpoint that requires user authentication'
 
-    context 'when the resource owner rejects the authorization grant' do
-      let(:approve) { 'false' }
-
-      it 'redirects to client redirection_uri with state and error params' do
-        call_endpoint
-        expect(response).to redirect_to('http://localhost:3000/?error=access_denied&state=foo')
-      end
-    end
-
     context 'when the resource owner approves the authorization grant' do
+      context 'when the authorization grant is successfully created' do
+        it 'creates an authorization grant and redirects to client redirection_uri with state and code params' do
+          aggregate_failures do
+            expect { call_endpoint }.to change(AuthorizationGrant, :count)
+            expect(response).to redirect_to("http://localhost:3000/?code=#{AuthorizationGrant.last.id}&state=foo")
+          end
+        end
+      end
+
       context 'when the authorization grant fails to create' do
         let(:authorization_grant_double) { instance_double(AuthorizationGrant, save: false) }
 
@@ -63,21 +64,15 @@ RSpec.describe OAuth::AuthorizationGrantsController do
           call_endpoint
           expect(response).to redirect_to('http://localhost:3000/?error=invalid_request&state=foo')
         end
-
-        it 'does not create an authorization grant' do
-          expect { call_endpoint }.not_to change(AuthorizationGrant, :count)
-        end
       end
+    end
 
-      context 'when the authorization grant is successfully created' do
-        it 'redirects to client redirection_uri with state and code params' do
-          call_endpoint
-          expect(response).to redirect_to("http://localhost:3000/?code=#{AuthorizationGrant.last.id}&state=foo")
-        end
+    context 'when the resource owner rejects the authorization grant' do
+      let(:approve) { 'false' }
 
-        it 'creates an authorization grant' do
-          expect { call_endpoint }.to change(AuthorizationGrant, :count)
-        end
+      it 'redirects to client redirection_uri with state and error params' do
+        call_endpoint
+        expect(response).to redirect_to('http://localhost:3000/?error=access_denied&state=foo')
       end
     end
   end

--- a/spec/requests/oauth/authorizations_controller_spec.rb
+++ b/spec/requests/oauth/authorizations_controller_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe OAuth::AuthorizationsController do
   describe 'GET /authorize' do
-    let(:headers) { {} }
     let(:params) { { client_id:, state:, code_challenge:, code_challenge_method:, response_type: } }
     let(:client_id) { 'democlient' }
     let(:state) { 'foobar' }

--- a/spec/requests/oauth/sessions_controller_spec.rb
+++ b/spec/requests/oauth/sessions_controller_spec.rb
@@ -4,22 +4,12 @@ require 'rails_helper'
 
 RSpec.describe OAuth::SessionsController do
   describe 'POST /token (grant_type="authorization_code")' do
-    let(:headers) { {} }
+    let_it_be(:user) { create(:user) }
+    let_it_be(:authorization_grant) { create(:authorization_grant, user:) }
     let(:params) { { code:, code_verifier:, grant_type: } }
     let(:grant_type) { 'authorization_code' }
     let(:code_verifier) { 'code_verifier' }
     let(:code) { authorization_grant.id }
-    let(:authorization_grant) { create(:authorization_grant, user:) }
-    let(:user) { create(:user) }
-
-    let(:oauth_token_encoder_service) { instance_double(OAuthTokenEncoderService) }
-    let(:access_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'access_token'] }
-    let(:refresh_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'refresh_token'] }
-
-    before do
-      allow(OAuthTokenEncoderService).to receive(:new).and_return(oauth_token_encoder_service)
-      allow(oauth_token_encoder_service).to receive(:call).and_return(access_token_results, refresh_token_results)
-    end
 
     include_context 'with an authenticated client', :post, :oauth_create_session_path
 
@@ -28,65 +18,62 @@ RSpec.describe OAuth::SessionsController do
     context 'when the authorization grant is not found' do
       let(:code) { 'foobar' }
 
-      it 'responds with HTTP status bad request' do
+      it 'responds with HTTP status bad request and error invalid_grant as JSON' do
         call_endpoint
-        expect(response).to have_http_status(:bad_request)
-      end
-
-      it 'responds with error invalid_grant as JSON' do
-        call_endpoint
-        expect(response.parsed_body).to eq({ 'error' => 'invalid_grant' })
+        aggregate_failures do
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to eq({ 'error' => 'invalid_grant' })
+        end
       end
     end
 
     context 'when the authorization grant has already been redeemed' do
       let(:authorization_grant) { create(:authorization_grant, user:, redeemed: true) }
 
-      it 'responds with HTTP status bad request' do
+      it 'responds with HTTP status bad request and error invalid_grant as JSON' do
         call_endpoint
-        expect(response).to have_http_status(:bad_request)
-      end
-
-      it 'responds with error invalid_grant as JSON' do
-        call_endpoint
-        expect(response.parsed_body).to eq({ 'error' => 'invalid_grant' })
+        aggregate_failures do
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to eq({ 'error' => 'invalid_grant' })
+        end
       end
     end
 
     context 'when an invalid code verifier is provided' do
       let(:code_verifier) { 'foobar' }
 
-      it 'responds with HTTP status bad request' do
+      it 'responds with HTTP status bad request and error invalid_grant as JSON' do
         call_endpoint
-        expect(response).to have_http_status(:bad_request)
-      end
-
-      it 'responds with error invalid_grant as JSON' do
-        call_endpoint
-        expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+        aggregate_failures do
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+        end
       end
     end
 
     context 'when all params are valid' do
-      it 'creates an OAuthSession record' do
-        expect { call_endpoint }.to change(OAuthSession, :count).by(1)
+      let(:oauth_token_encoder_service) { instance_double(OAuthTokenEncoderService) }
+      let(:access_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'access_token'] }
+      let(:refresh_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'refresh_token'] }
+
+      before do
+        allow(OAuthTokenEncoderService).to receive(:new).and_return(oauth_token_encoder_service)
+        allow(oauth_token_encoder_service).to receive(:call).and_return(access_token_results, refresh_token_results)
       end
 
-      it 'responds with HTTP status ok' do
-        call_endpoint
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'renders the serialized token data' do
-        call_endpoint
-        expect(response.parsed_body).to include(
-          {
-            'access_token' => 'access_token',
-            'refresh_token' => 'refresh_token',
-            'token_type' => 'bearer',
-            'expires_in' => 5.minutes.from_now.to_i
-          }
-        )
+      it 'creates an OAuth session and serializes the token data' do # rubocop:disable RSpec/ExampleLength
+        aggregate_failures do
+          expect { call_endpoint }.to change(OAuthSession, :count).by(1)
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(
+            {
+              'access_token' => 'access_token',
+              'refresh_token' => 'refresh_token',
+              'token_type' => 'bearer',
+              'expires_in' => 5.minutes.from_now.to_i
+            }
+          )
+        end
       end
 
       context 'when oauth token creation raises the server error' do
@@ -97,36 +84,24 @@ RSpec.describe OAuth::SessionsController do
           allow(authorization_grant_spy).to receive(:redeem).and_raise(OAuth::ServerError, 'foobar')
         end
 
-        it 'responds with HTTP status internal_server_error' do
+        it 'responds with HTTP status internal_server_error and error server_error as JSON' do
           call_endpoint
-          expect(response).to have_http_status(:internal_server_error)
-        end
-
-        it 'responds with error server_error as JSON' do
-          call_endpoint
-          expect(response.parsed_body).to eq({ 'error' => 'server_error' })
+          aggregate_failures do
+            expect(response).to have_http_status(:internal_server_error)
+            expect(response.parsed_body).to eq({ 'error' => 'server_error' })
+          end
         end
       end
     end
   end
 
   describe 'POST /token (grant_type="refresh_token")' do
-    let(:headers) { {} }
+    let_it_be(:user) { create(:user) }
+    let_it_be(:authorization_grant) { create(:authorization_grant, user:) }
     let(:params) { { grant_type:, refresh_token: } }
     let(:grant_type) { 'refresh_token' }
     let(:refresh_token) { JsonWebToken.encode(attributes_for(:refresh_token, oauth_session:)) }
     let!(:oauth_session) { create(:oauth_session, authorization_grant:) }
-    let(:authorization_grant) { create(:authorization_grant, user:) }
-    let(:user) { create(:user) }
-
-    let(:oauth_token_encoder_service) { instance_double(OAuthTokenEncoderService) }
-    let(:access_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'access_token'] }
-    let(:refresh_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'refresh_token'] }
-
-    before do
-      allow(OAuthTokenEncoderService).to receive(:new).and_return(oauth_token_encoder_service)
-      allow(oauth_token_encoder_service).to receive(:call).and_return(access_token_results, refresh_token_results)
-    end
 
     include_context 'with an authenticated client', :post, :oauth_refresh_session_path
 
@@ -135,33 +110,28 @@ RSpec.describe OAuth::SessionsController do
     context 'when the client provides an invalid JWT for refresh token' do
       let(:refresh_token) { 'foobar' }
 
-      it 'responds with HTTP status bad request' do
+      it 'responds with HTTP status bad request and error unsupported_grant_type as JSON' do
         call_endpoint
-        expect(response).to have_http_status(:bad_request)
-      end
-
-      it 'responds with error unsupported_grant_type as JSON' do
-        call_endpoint
-        expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+        aggregate_failures do
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+        end
       end
     end
 
     context 'when oauth token creation raises the revoked session error' do
       let(:oauth_session) { create(:oauth_session, authorization_grant:, status: 'refreshed') }
 
-      it 'responds with HTTP status bad request' do
+      it 'responds with HTTP status bad request and error invalid_request as JSON' do
         call_endpoint
-        expect(response).to have_http_status(:bad_request)
-      end
-
-      it 'responds with error server_error as JSON' do
-        call_endpoint
-        expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+        aggregate_failures do
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to eq({ 'error' => 'invalid_request' })
+        end
       end
 
       context 'with the same oauth session' do
-        # rubocop:disable RSpec/ExampleLength
-        it 'logs the refresh replay attack details' do
+        it 'logs the refresh replay attack details' do # rubocop:disable RSpec/ExampleLength
           logger_spy = instance_spy(ActiveSupport::Logger)
           allow(Rails).to receive(:logger).and_return(logger_spy)
           call_endpoint
@@ -177,14 +147,11 @@ RSpec.describe OAuth::SessionsController do
               )
             )
         end
-        # rubocop:enable RSpec/ExampleLength
       end
 
       context 'with a different active oauth session' do
-        let!(:active_oauth_session) { create(:oauth_session, authorization_grant:) }
-
-        # rubocop:disable RSpec/ExampleLength
-        it 'logs the refresh replay attack details' do
+        it 'logs the refresh replay attack details' do # rubocop:disable RSpec/ExampleLength
+          active_oauth_session = create(:oauth_session, authorization_grant:)
           logger_spy = instance_spy(ActiveSupport::Logger)
           allow(Rails).to receive(:logger).and_return(logger_spy)
           call_endpoint
@@ -200,30 +167,32 @@ RSpec.describe OAuth::SessionsController do
               )
             )
         end
-        # rubocop:enable RSpec/ExampleLength
       end
     end
 
     context 'when all params are valid' do
-      it 'creates an OAuthSession record' do
-        expect { call_endpoint }.to change(OAuthSession, :count).by(1)
+      let(:oauth_token_encoder_service) { instance_double(OAuthTokenEncoderService) }
+      let(:access_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'access_token'] }
+      let(:refresh_token_results) { OAuthTokenEncoderService::Response[SecureRandom.uuid, 'refresh_token'] }
+
+      before do
+        allow(OAuthTokenEncoderService).to receive(:new).and_return(oauth_token_encoder_service)
+        allow(oauth_token_encoder_service).to receive(:call).and_return(access_token_results, refresh_token_results)
       end
 
-      it 'responds with HTTP status ok' do
-        call_endpoint
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'renders the serialized token data' do
-        call_endpoint
-        expect(response.parsed_body).to include(
-          {
-            'access_token' => 'access_token',
-            'refresh_token' => 'refresh_token',
-            'token_type' => 'bearer',
-            'expires_in' => 5.minutes.from_now.to_i
-          }
-        )
+      it 'creates an OAuth session and responds with the serialized token data' do # rubocop:disable RSpec/ExampleLength
+        aggregate_failures do
+          expect { call_endpoint }.to change(OAuthSession, :count).by(1)
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(
+            {
+              'access_token' => 'access_token',
+              'refresh_token' => 'refresh_token',
+              'token_type' => 'bearer',
+              'expires_in' => 5.minutes.from_now.to_i
+            }
+          )
+        end
       end
 
       context 'when oauth token creation raises the server error' do
@@ -234,49 +203,44 @@ RSpec.describe OAuth::SessionsController do
           allow(oauth_session_spy).to receive(:refresh).and_raise(OAuth::ServerError, 'foobar')
         end
 
-        it 'responds with HTTP status internal_server_error' do
+        it 'responds with HTTP status internal_server_error and error server_error as JSON' do
           call_endpoint
-          expect(response).to have_http_status(:internal_server_error)
-        end
-
-        it 'responds with error server_error as JSON' do
-          call_endpoint
-          expect(response.parsed_body).to eq({ 'error' => 'server_error' })
+          aggregate_failures do
+            expect(response).to have_http_status(:internal_server_error)
+            expect(response.parsed_body).to eq({ 'error' => 'server_error' })
+          end
         end
       end
     end
   end
 
   describe 'POST /token (grant_type={ NOT `authorization_code` or `refresh_token` })' do
-    let(:headers) { {} }
+    let_it_be(:user) { create(:user) }
+    let_it_be(:authorization_grant) { create(:authorization_grant, user:) }
     let(:params) { { code:, code_verifier:, grant_type: } }
     let(:grant_type) { 'foobar' }
     let(:code_verifier) { 'code_verifier' }
     let(:code) { authorization_grant.id }
-    let(:authorization_grant) { create(:authorization_grant, user:) }
-    let(:user) { create(:user) }
 
     include_context 'with an authenticated client', :post, :oauth_unsupported_grant_type_path
 
     it_behaves_like 'an endpoint that requires client authentication'
 
-    it 'responds with HTTP status bad request' do
+    it 'responds with HTTP status bad request and error unsupported_grant_type as JSON' do
       call_endpoint
-      expect(response).to have_http_status(:bad_request)
-    end
-
-    it 'responds with error unsupported_grant_type as JSON' do
-      call_endpoint
-      expect(response.parsed_body).to eq({ 'error' => 'unsupported_grant_type' })
+      aggregate_failures do
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq({ 'error' => 'unsupported_grant_type' })
+      end
     end
   end
 
   describe 'POST /revoke (token_type_hint={ NOT `access_token` or `refresh_token` })' do
-    let(:headers) { {} }
+    let_it_be(:user) { create(:user) }
+    let_it_be(:authorization_grant) { create(:authorization_grant, user:, redeemed: true) }
     let(:params) { { token:, token_type_hint: 'foobar' } }
     let(:token) { JsonWebToken.encode(attributes_for(:access_token, oauth_session:)) }
     let(:oauth_session) { create(:oauth_session, authorization_grant:) }
-    let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
 
     include_context 'with an authenticated client', :post, :oauth_revoke_path
 
@@ -295,11 +259,11 @@ RSpec.describe OAuth::SessionsController do
   end
 
   describe 'POST /revoke (token_type_hint=access_token)' do
-    let(:headers) { {} }
+    let_it_be(:user) { create(:user) }
+    let_it_be(:authorization_grant) { create(:authorization_grant, user:, redeemed: true) }
     let(:params) { { token:, token_type_hint: 'access_token' } }
     let(:token) { JsonWebToken.encode(attributes_for(:access_token, oauth_session:)) }
     let(:oauth_session) { create(:oauth_session, authorization_grant:) }
-    let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
 
     include_context 'with an authenticated client', :post, :oauth_revoke_access_token_path
 
@@ -318,11 +282,11 @@ RSpec.describe OAuth::SessionsController do
   end
 
   describe 'POST /revoke (token_type_hint=refresh_token})' do
-    let(:headers) { {} }
+    let_it_be(:user) { create(:user) }
+    let_it_be(:authorization_grant) { create(:authorization_grant, user:, redeemed: true) }
     let(:params) { { token:, token_type_hint: 'refresh_token' } }
     let(:token) { JsonWebToken.encode(attributes_for(:refresh_token, oauth_session:)) }
     let(:oauth_session) { create(:oauth_session, authorization_grant:) }
-    let(:authorization_grant) { create(:authorization_grant, redeemed: true) }
 
     include_context 'with an authenticated client', :post, :oauth_revoke_refresh_token_path
 

--- a/spec/services/state_token_encoder_service_spec.rb
+++ b/spec/services/state_token_encoder_service_spec.rb
@@ -65,12 +65,11 @@ RSpec.describe StateTokenEncoderService do
     end
 
     context 'with valid arguments' do
-      it 'returns ok status' do
-        expect(service_call.status).to eq(:ok)
-      end
-
-      it 'returns a valid JWT token' do
-        expect(service_call.body).to match(/\A[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\z/)
+      it 'returns HTTP ok status and a valid JWT token' do
+        aggregate_failures do
+          expect(service_call.status).to eq(:ok)
+          expect(service_call.body).to match(/\A[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\z/)
+        end
       end
 
       it 'returns a token which contains the code_challenge and code_challenge_method' do

--- a/spec/support/shared/claim_validatable.rb
+++ b/spec/support/shared/claim_validatable.rb
@@ -2,19 +2,33 @@
 
 RSpec.shared_examples 'a model that validates token claims' do
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:aud) }
-    it { is_expected.not_to allow_value('http://foo.bar/api').for(:aud) }
-
-    it { is_expected.to validate_presence_of(:exp) }
-    it { is_expected.not_to allow_value(5.minutes.ago.to_i).for(:exp) }
-
-    it { is_expected.to validate_presence_of(:iss) }
-    it { is_expected.not_to allow_value('http://foo.bar/').for(:iss) }
-
-    it { is_expected.to validate_presence_of(:jti) }
-
     it 'does not add any errors if all provided claims are valid' do
       expect(model).to be_valid
+    end
+
+    describe 'aud' do
+      specify(:aggregate_failures) do
+        expect(model).to validate_presence_of(:aud)
+        expect(model).not_to allow_value('http://foo.bar/api').for(:aud)
+      end
+    end
+
+    describe 'exp' do
+      specify(:aggregate_failures) do
+        expect(model).to validate_presence_of(:exp)
+        expect(model).not_to allow_value(5.minutes.ago.to_i).for(:exp)
+      end
+    end
+
+    describe 'iss' do
+      specify(:aggregate_failures) do
+        expect(model).to validate_presence_of(:iss)
+        expect(model).not_to allow_value('http://foo.bar/').for(:iss)
+      end
+    end
+
+    describe 'jti' do
+      it { is_expected.to validate_presence_of(:jti) }
     end
   end
 

--- a/spec/support/shared/client_authentication.rb
+++ b/spec/support/shared/client_authentication.rb
@@ -5,10 +5,9 @@ RSpec.shared_context 'with an authenticated client' do |method, path|
 
   let(:url) { send(path) }
   let(:options_for_request) { { params: shared_context_params, headers: shared_context_headers } }
-  let(:shared_context_params) { params.reverse_merge!(client_id: 'democlient') }
-  let(:shared_context_headers) { headers.reverse_merge!(http_basic_auth_header) }
-
-  def http_basic_auth_header
+  let(:shared_context_params) { (try(:params) || {}).reverse_merge!(client_id: 'democlient') }
+  let(:shared_context_headers) { (try(:headers) || {}).reverse_merge!(http_basic_auth_header) }
+  let(:http_basic_auth_header) do
     client_id = 'democlient'
     client_secret = Rails.application.credentials.clients[client_id.to_sym]
     auth = ActionController::HttpAuthentication::Basic.encode_credentials(client_id, client_secret)
@@ -17,31 +16,25 @@ RSpec.shared_context 'with an authenticated client' do |method, path|
 end
 
 RSpec.shared_examples 'an endpoint that requires client authentication' do
+  shared_examples 'returns HTTP status unauthorized and access denied message' do
+    it 'returns HTTP status unauthorized and access denied message' do
+      call_endpoint
+      aggregate_failures do
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body.chomp).to eq('HTTP Basic: Access denied.')
+      end
+    end
+  end
+
   context 'with client_id param that does not match client id in header' do
     let(:shared_context_params) { super().merge(client_id: 'negativetestclient') }
 
-    it 'returns HTTP status unauthorized' do
-      call_endpoint
-      expect(response).to have_http_status(:unauthorized)
-    end
-
-    it 'returns an access denied message' do
-      call_endpoint
-      expect(response.body.chomp).to eq('HTTP Basic: Access denied.')
-    end
+    include_examples 'returns HTTP status unauthorized and access denied message'
   end
 
   context 'without HTTP basic auth header' do
     let(:shared_context_headers) { super().except('HTTP_AUTHORIZATION') }
 
-    it 'returns HTTP status unauthorized' do
-      call_endpoint
-      expect(response).to have_http_status(:unauthorized)
-    end
-
-    it 'returns an access denied message' do
-      call_endpoint
-      expect(response.body.chomp).to eq('HTTP Basic: Access denied.')
-    end
+    include_examples 'returns HTTP status unauthorized and access denied message'
   end
 end

--- a/spec/support/shared/token_authentication.rb
+++ b/spec/support/shared/token_authentication.rb
@@ -68,13 +68,13 @@ RSpec.shared_context 'with a valid access token' do |method, path|
 
   let(:url) { send(path) }
   let(:options_for_request) { { params: shared_context_params, headers: shared_context_headers } }
-  let(:shared_context_params) { params }
-  let(:shared_context_headers) { headers.reverse_merge!(bearer_token_header) }
+  let(:shared_context_params) { try(:params) || {} }
+  let(:shared_context_headers) { (try(:headers) || {}).reverse_merge!(bearer_token_header) }
 
-  let(:authorization_grant) { create(:authorization_grant, user:) }
-  let(:oauth_session) { create(:oauth_session, authorization_grant:) }
+  let_it_be(:authorization_grant) { create(:authorization_grant, user:) }
+  let_it_be(:oauth_session) { create(:oauth_session, authorization_grant:) }
 
-  def bearer_token_header
+  let(:bearer_token_header) do
     _, token = OAuthTokenEncoderService.call(
       client_id: 'democlient',
       expiration: Rails.configuration.oauth.access_token_expiration.minutes.from_now,

--- a/spec/support/shared/user_authentication.rb
+++ b/spec/support/shared/user_authentication.rb
@@ -6,6 +6,10 @@ RSpec.shared_examples 'an endpoint that requires user authentication' do
       delete sign_out_path
     end
 
+    after do
+      sign_in(user)
+    end
+
     it 'redirects to the sign_in page' do
       call_endpoint
       expect(response).to redirect_to(sign_in_path)

--- a/spec/views/oauth/authorization_grants/new.html.tailwindcss_spec.rb
+++ b/spec/views/oauth/authorization_grants/new.html.tailwindcss_spec.rb
@@ -7,16 +7,12 @@ RSpec.describe 'oauth/authorization_grants/new' do
     render template: 'oauth/authorization_grants/new', locals: { state: 'foo', client_name: 'bar' }
   end
 
-  it 'renders the title' do
-    expect(rendered).to match(/#{I18n.t('oauth.authorization_grants.new.title')}/)
-  end
-
-  it 'renders the lede' do
-    expect(rendered).to match(/#{I18n.t('oauth.authorization_grants.new.lede')}/)
-  end
-
-  it 'renders the client name' do
-    expect(rendered).to match(/bar/)
+  it 'renders the title, lede, and client name' do
+    aggregate_failures do
+      expect(rendered).to match(/#{I18n.t('oauth.authorization_grants.new.title')}/)
+      expect(rendered).to match(/#{I18n.t('oauth.authorization_grants.new.lede')}/)
+      expect(rendered).to match(/bar/)
+    end
   end
 
   it 'renders the reject cta' do

--- a/spec/views/oauth/client_error.html.tailwindcss_spec.rb
+++ b/spec/views/oauth/client_error.html.tailwindcss_spec.rb
@@ -7,19 +7,12 @@ RSpec.describe 'oauth/client_error' do
     render template: 'oauth/client_error', locals: { error_class: 'foo', error_message: 'bar' }
   end
 
-  it 'renders the title' do
-    expect(rendered).to match(/#{I18n.t('oauth.client_error.title')}/)
-  end
-
-  it 'renders the lede' do
-    expect(rendered).to match(/#{I18n.t('oauth.client_error.lede')}/)
-  end
-
-  it 'renders the error class' do
-    expect(rendered).to match(/foo/)
-  end
-
-  it 'renders the error message' do
-    expect(rendered).to match(/bar/)
+  it 'renders the title, lede, error class, and error message' do
+    aggregate_failures do
+      expect(rendered).to match(/#{I18n.t('oauth.client_error.title')}/)
+      expect(rendered).to match(/#{I18n.t('oauth.client_error.lede')}/)
+      expect(rendered).to match(/foo/)
+      expect(rendered).to match(/bar/)
+    end
   end
 end


### PR DESCRIPTION
## Description

This PR adds the `test-prof` gem for evaluating test suite performance and updates the README to include its instructions. It also refactors each spec to demonstrate improvements one can make using the tool.

Previous execution time:

```
Finished in 1 minute 27.56 seconds (files took 0.81998 seconds to load)
```

Execution time after only refactoring the worst performing spec (`spec/models/oauth_session_spec.rb`):

```
Finished in 51.87 seconds (files took 0.887 seconds to load)
```

Execution time after all changes on this PR:

```
Finished in 19.21 seconds (files took 0.91638 seconds to load)
```

## Testing

Follow these steps to test this PR:

* Run the test suite on master and record the total execution time.
* Run the test suite on this branch and record the total execution time.
* Experiment with some of the commands listed in the README.
