### PR TITLE
Adding arm64-darwin-21 to gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,7 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 


### PR DESCRIPTION
## Description

This PR adds arm64-darwin-21 to the gemfile.lock.


## Testing

Follow these steps to test this PR: All Github actions should pass, making sure it builds.
