### PR TITLE
Add Exchange route and basic Exchange spec and action

### DIFF
--- a/app/controllers/oauth/sessions_controller.rb
+++ b/app/controllers/oauth/sessions_controller.rb
@@ -4,8 +4,6 @@ module OAuth
   ##
   # Controller for issuing access and refresh tokens.
   class SessionsController < BaseController
-    PERMITTED_GRANT_TYPES = %w[authorization_code refresh_token].freeze
-
     skip_before_action :verify_authenticity_token
 
     rescue_from OAuth::InvalidGrantError do
@@ -42,6 +40,10 @@ module OAuth
     rescue OAuth::RevokedSessionError => error
       Rails.logger.warn(error.message)
       render_token_request_error(error: 'invalid_request')
+    end
+
+    def exchange
+      head :ok
     end
 
     def unsupported_grant_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,10 @@ Rails.application.routes.draw do
       post 'token', to: 'sessions#token', as: :create_session
     end
 
+    constraints(GrantTypeConstraint.new('urn:ietf:params:oauth:grant-type:token-exchange')) do
+      post 'token', to: 'sessions#exchange', as: :exchange_session
+    end
+
     post 'token', to: 'sessions#unsupported_grant_type', as: :unsupported_grant_type
 
     constraints(TokenTypeHintConstraint.new('access_token')) do

--- a/spec/requests/oauth/sessions_controller_spec.rb
+++ b/spec/requests/oauth/sessions_controller_spec.rb
@@ -214,6 +214,22 @@ RSpec.describe OAuth::SessionsController do
     end
   end
 
+  describe 'POST /token (grant_type="urn:ietf:params:oauth:grant-type:token-exchange")' do
+    let_it_be(:user) { create(:user) }
+    let_it_be(:authorization_grant) { create(:authorization_grant, user:) }
+    let(:params) { { grant_type: } }
+    let(:grant_type) { 'urn:ietf:params:oauth:grant-type:token-exchange' }
+
+    include_context 'with an authenticated client', :post, :oauth_create_session_path
+
+    it_behaves_like 'an endpoint that requires client authentication'
+
+    it 'creates an OAuth session and serializes the token data' do
+      call_endpoint
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe 'POST /token (grant_type={ NOT `authorization_code` or `refresh_token` })' do
     let_it_be(:user) { create(:user) }
     let_it_be(:authorization_grant) { create(:authorization_grant, user:) }


### PR DESCRIPTION
## Description

This PR adds a new route to sessions #exchange. It adds a basic exchange action in `app/controllers/oauth/sessions_controller.rb` and a basic spec for it.


## Testing

Follow these steps to test this PR: We can single out this test suite in `spec/requests/oauth/sessions_controller_spec.rb` or run the whole test suite.