### PR TITLE
Add validations to exchange action in sessions controller

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -67,3 +67,7 @@ detectors:
     exclude:
       - AccessToken#valid_exp?
       - API::BaseController#user_from_token
+  UtilityFunction:
+    exclude:
+      - OAuthSessionExchangeable#valid_resource?
+      - OAuthSessionExchangeable#valid_subject_token_type?

--- a/app/models/concerns/oauth_session_exchangeable.rb
+++ b/app/models/concerns/oauth_session_exchangeable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+##
+# Provides support for validating token claims
+module OAuthSessionExchangeable
+  extend ActiveSupport::Concern
+
+  VALID_URIS = ['/api/v1/users/current'].freeze
+  VALID_TOKEN_TYPES = ['urn:ietf:params:oauth:token-type:access_token'].freeze
+
+  def validate_params_for_exchange!(resource:, subject_token_type:)
+    raise OAuth::InvalidResourceError unless valid_resource?(resource)
+
+    return if valid_subject_token_type?(subject_token_type)
+
+    raise OAuth::InvalidSubjectTokenTypeError
+  end
+
+  private
+
+  def valid_resource?(resource)
+    resource.present? && VALID_URIS.include?(resource)
+  end
+
+  def valid_subject_token_type?(subject_token_type)
+    subject_token_type.present? && VALID_TOKEN_TYPES.include?(subject_token_type)
+  end
+end

--- a/app/models/oauth_session.rb
+++ b/app/models/oauth_session.rb
@@ -4,6 +4,7 @@
 # Models an oauth session with minimal data from session.
 class OAuthSession < ApplicationRecord
   include OAuthSessionCreatable
+  include OAuthSessionExchangeable
 
   STATUS_ENUM_VALUES = {
     created: 'created',

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -24,8 +24,20 @@ module OAuth
   class UnsupportedGrantTypeError < StandardError; end
 
   ##
+  # Error for when OAuth Session is not found.
+  class OAuthSessionNotFound < StandardError; end
+
+  ##
   # Error for when client provides a code that does not map to an valid authorization grant.
   class InvalidGrantError < StandardError; end
+
+  ##
+  # Error for when the resource probided fails validation.
+  class InvalidResourceError < StandardError; end
+
+  ##
+  # Error for when the subject token type fails validation.
+  class InvalidSubjectTokenTypeError < StandardError; end
 
   ##
   # Error for when client provides a code verifier that fails validation.


### PR DESCRIPTION
This PR...

Adds validations to the `#exchange` action in sessions_controller.rb. It is validating the presence of `resource:` and `subject_token_type:`.

Follow these steps to test this PR:

Run `bundle exec rspec spec/requests/oauth/sessions_controller_spec.rb`
