### PR TITLE
Restrict api key generation to only confidential client type

### DIFF
--- a/app/models/oauth/client.rb
+++ b/app/models/oauth/client.rb
@@ -28,6 +28,8 @@ module OAuth
     end
 
     def generate_api_key
+      return if client_type == 'public'
+
       self.api_key = SecureRandom.hex
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,3 +4,8 @@ client = OAuth::Client.find_or_initialize_by(name: 'Sample Client') do |c|
   c.redirect_uri = 'http://localhost:3000/'
 end
 client.save if client.new_record?
+
+OAuth::Client.find_or_initialize_by(name: 'Public Client') do |c|
+  c.client_type = 'public'
+  c.redirect_uri = 'http://localhost:3000/'
+end

--- a/script/generate_link_for_authorize_endpoint.rb
+++ b/script/generate_link_for_authorize_endpoint.rb
@@ -4,8 +4,9 @@ require 'digest'
 
 code_verifier = SecureRandom.base64(55).tr('+/', '-_').tr('=', '')
 code_challenge = Digest::SHA256.base64digest(code_verifier).tr('+/', '-_').tr('=', '')
-client_id = 'democlient'
-client_secret = Rails.application.credentials.clients[client_id.to_sym]
+client = OAuth::Client.where(client_type: 'confidential').first
+client_id = client.id
+client_secret = client.api_key
 
 puts <<~TEXT
   Copy down the code verifier and code challenge for referencing later in the process when using Postman to send requests.

--- a/spec/models/oauth/client_spec.rb
+++ b/spec/models/oauth/client_spec.rb
@@ -66,8 +66,17 @@ RSpec.describe OAuth::Client do # rubocop:disable RSpec/FilePath
 
   describe 'callbacks' do
     describe '#generate_api_key' do
-      it 'generates an API key when a new client is created' do
-        expect { model.save! }.to change(model, :api_key).from(nil).to(be_present)
+      context 'when client type is confidential' do
+        it 'generates an API key when a new client is created' do
+          expect { model.save! }.to change(model, :api_key).from(nil).to(be_present)
+        end
+      end
+
+      context 'when client type is public' do
+        it 'do not generate an API key when a new client is created' do
+          model.client_type = 'public'
+          expect { model.save! }.not_to change(model, :api_key).from(nil)
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

This PR...

Restricts api key generation to only confidential client_type.


## Testing

Follow these steps to test this PR:

* ...
* ...
* ...
